### PR TITLE
Add accurate useEffect deps to fix infinite loop on proposals index

### DIFF
--- a/client/pages/proposal/index.tsx
+++ b/client/pages/proposal/index.tsx
@@ -63,7 +63,7 @@ const Proposal: NextPage = ({ proposalCount, proposals }) => {
     if (networkInfo.correct && contracts.loaded) {
       load();
     }
-  }, [proposals, setProposalData, contracts.Governance, networkInfo]);
+  }, [proposals, setProposalData, contracts.loaded, contracts.Governance, networkInfo.correct]);
 
   return (
     <>

--- a/client/pages/proposal/index.tsx
+++ b/client/pages/proposal/index.tsx
@@ -63,7 +63,13 @@ const Proposal: NextPage = ({ proposalCount, proposals }) => {
     if (networkInfo.correct && contracts.loaded) {
       load();
     }
-  }, [proposals, setProposalData, contracts.loaded, contracts.Governance, networkInfo.correct]);
+  }, [
+    proposals,
+    setProposalData,
+    contracts.loaded,
+    contracts.Governance,
+    networkInfo.correct,
+  ]);
 
   return (
     <>


### PR DESCRIPTION
With an empty set of proposals locally, the proposals index template crashes the app. This hotfix adds accurate dependencies to prevent infinite re-rendering, allowing the page to load.