### PR TITLE
Add token stats panel

### DIFF
--- a/client/components/Card.tsx
+++ b/client/components/Card.tsx
@@ -6,6 +6,7 @@ interface CardProps {
   dark?: Boolean;
   tightPadding?: Boolean;
   noPadding?: Boolean;
+  alt?: Boolean;
 }
 
 const Card: FunctionComponent<CardProps> = ({
@@ -13,14 +14,16 @@ const Card: FunctionComponent<CardProps> = ({
   dark,
   tightPadding,
   noPadding,
+  alt,
 }) => {
   const classes = classNames(
     "overflow-x-auto w-full shadow-lg rounded-lg border h-full",
     {
-      "bg-secondary-focus text-white border-black": dark,
-      "bg-white text-black": !dark,
+      "bg-secondary-focus text-white border-black": dark && !alt,
+      "bg-white text-black": !dark && !alt,
       "p-4 md:p-5": tightPadding && !noPadding,
       "p-6 md:p-10": !tightPadding && !noPadding,
+      "bg-gray-100": alt && !dark,
     }
   );
 

--- a/client/components/CardGroup.tsx
+++ b/client/components/CardGroup.tsx
@@ -4,19 +4,22 @@ import classNames from "classnames";
 interface CardGroupProps {
   children: ReactNode;
   horizontal?: Boolean;
+  twoCol?: Boolean;
   fourCol?: Boolean;
 }
 
 const CardGroup: FunctionComponent<CardGroupProps> = ({
   children,
   horizontal,
+  twoCol,
   fourCol,
 }) => {
   const classes = classNames("w-full", {
     "grid gap-2": horizontal,
     "space-y-5": !horizontal,
+    "sm:grid-cols-2": twoCol,
     "sm:grid-cols-4": fourCol,
-    "sm:grid-cols-3": !fourCol,
+    "sm:grid-cols-3": !twoCol && !fourCol,
   });
 
   return <div className={classes}>{children}</div>;

--- a/client/components/vote-escrow/LockupStats.tsx
+++ b/client/components/vote-escrow/LockupStats.tsx
@@ -25,7 +25,7 @@ const LockupStats: FunctionComponent<LockupStatsProps> = ({
 
   const percentageLockedUp =
     (parseInt(totalTokensLockedUp) / totalSupply) * 100;
-  const averageLockupLength = totalLockupWeeks / lockupCount;
+  const averageLockupLength = Math.round(totalLockupWeeks / lockupCount);
 
   return (
     <Card alt>

--- a/client/components/vote-escrow/LockupStats.tsx
+++ b/client/components/vote-escrow/LockupStats.tsx
@@ -1,0 +1,19 @@
+import { FunctionComponent } from "react";
+import { useStore } from "utils/store";
+import Card from "components/Card";
+import { SectionTitle } from "components/SectionTitle";
+
+const LockupStats: FunctionComponent = () => {
+  const { totalBalances } = useStore();
+  const { totalSupply, lockedUpSupply } = totalBalances;
+
+  return (
+    <Card>
+      <SectionTitle>Total Lockup Stats</SectionTitle>
+      <p>{totalSupply.toString()}</p>
+      <p>{lockedUpSupply.toString()}</p>
+    </Card>
+  );
+};
+
+export default LockupStats;

--- a/client/components/vote-escrow/LockupStats.tsx
+++ b/client/components/vote-escrow/LockupStats.tsx
@@ -1,17 +1,53 @@
 import { FunctionComponent } from "react";
 import { useStore } from "utils/store";
+import CardGroup from "components/CardGroup";
 import Card from "components/Card";
+import CardLabel from "components/CardLabel";
+import CardStat from "components/CardStat";
 import { SectionTitle } from "components/SectionTitle";
 
-const LockupStats: FunctionComponent = () => {
+interface LockupStatsProps {
+  lockupCount: number;
+  totalLockupWeeks: number;
+  totalTokensLockedUp: string;
+}
+
+const LockupStats: FunctionComponent<LockupStatsProps> = ({
+  lockupCount,
+  totalLockupWeeks,
+  totalTokensLockedUp,
+}) => {
   const { totalBalances } = useStore();
-  const { totalSupply, lockedUpSupply } = totalBalances;
+
+  if (lockupCount === 0) return null;
+
+  const { totalSupply } = totalBalances;
+
+  const percentageLockedUp =
+    (parseInt(totalTokensLockedUp) / totalSupply) * 100;
+  const averageLockupLength = totalLockupWeeks / lockupCount;
 
   return (
-    <Card>
-      <SectionTitle>Total Lockup Stats</SectionTitle>
-      <p>{totalSupply.toString()}</p>
-      <p>{lockedUpSupply.toString()}</p>
+    <Card alt>
+      <SectionTitle>Total OGV lockup stats</SectionTitle>
+      <CardGroup horizontal twoCol>
+        <div>
+          <Card tightPadding>
+            <div className="space-y-1">
+              <CardLabel>Amount locked up</CardLabel>
+              <CardStat>{percentageLockedUp.toFixed(2)}%</CardStat>
+            </div>
+          </Card>
+        </div>
+        <div>
+          <Card tightPadding>
+            <div className="space-y-1">
+              <CardLabel>Average lock time</CardLabel>
+              <CardStat>{averageLockupLength} weeks</CardStat>
+            </div>
+          </Card>
+        </div>
+      </CardGroup>
     </Card>
   );
 };

--- a/client/listener.ts
+++ b/client/listener.ts
@@ -42,7 +42,7 @@ const contracts = [
     name: "VoteLockerCurve",
     address: GovernanceContracts.VoteLockerCurve.address,
     abi: GovernanceContracts.VoteLockerCurve.abi,
-    events: ["LockupCreated"],
+    events: ["LockupCreated", "LockupUpdated"],
   },
 ];
 
@@ -62,6 +62,7 @@ const ethereumEvents = new EthereumEvents(web3, contracts, options);
 
 const handleEvents = async (blockNumber, events, done) => {
   for (const event of events) {
+    const now = event.timestamp;
     if (event.name == "ProposalCreated") {
       try {
         await prisma.proposal.create({
@@ -73,6 +74,36 @@ const handleEvents = async (blockNumber, events, done) => {
         logger.info("Inserted new proposal");
       } catch (e) {
         // Likely duplicate
+      }
+    } else if(event.name === "LockupCreated") {
+      try {
+        await prisma.lockup.create({
+          data: {
+            address: event.values.provider,
+            amount: event.values.amount,
+            end: event.values.end,
+            weeks: parseInt(((event.values.end - now) / 604800).toFixed()),
+          },
+        });
+        logger.info("Inserted new lockup");
+      } catch (e) {
+        // Likely duplicate
+      }
+    } else if(event.name === "LockupUpdated") {
+      try {
+        await prisma.lockup.update({
+          where: {
+            address: event.values.provider,
+          },
+          data: {
+            amount: event.values.amount,
+            end: event.values.end,
+            weeks: parseInt(((event.values.end - now) / 604800).toFixed()),
+          }
+        });
+        logger.info("Updated existing lockup");
+      } catch (e) {
+        // Likely not found
       }
     } else {
       try {

--- a/client/listener.ts
+++ b/client/listener.ts
@@ -91,17 +91,24 @@ const handleEvents = async (blockNumber, events, done) => {
       }
     } else if(event.name === "LockupUpdated") {
       try {
-        await prisma.lockup.update({
+        await prisma.lockup.updateMany({
           where: {
             address: event.values.provider,
           },
           data: {
+            active: false,
+          }
+        });
+        logger.info("Updated existing lockup(s)");
+        await prisma.lockup.create({
+          data: {
+            address: event.values.provider,
             amount: event.values.amount,
             end: event.values.end,
             weeks: Math.round((event.values.end - now) / 604800),
-          }
+          },
         });
-        logger.info("Updated existing lockup");
+        logger.info("Inserted new lockup");
       } catch (e) {
         // Likely not found
       }

--- a/client/listener.ts
+++ b/client/listener.ts
@@ -82,7 +82,7 @@ const handleEvents = async (blockNumber, events, done) => {
             address: event.values.provider,
             amount: event.values.amount,
             end: event.values.end,
-            weeks: parseInt(((event.values.end - now) / 604800).toFixed()),
+            weeks: Math.round((event.values.end - now) / 604800),
           },
         });
         logger.info("Inserted new lockup");
@@ -98,7 +98,7 @@ const handleEvents = async (blockNumber, events, done) => {
           data: {
             amount: event.values.amount,
             end: event.values.end,
-            weeks: parseInt(((event.values.end - now) / 604800).toFixed()),
+            weeks: Math.round((event.values.end - now) / 604800),
           }
         });
         logger.info("Updated existing lockup");

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -8,11 +8,13 @@ import OUSDContracts from "networks/network.mainnet.json";
 import { mainnetNetworkUrl, RPC_URLS, CHAIN_CONTRACTS } from "constants/index";
 import { useStore } from "utils/store";
 import useAccountBalances from "utils/useAccountBalances";
+import useTotalBalances from "utils/useTotalBalances";
 import { TransactionListener } from "components/TransactionListener";
 
 export default function App({ Component, pageProps }) {
   const { web3Provider, contracts, chainId } = useStore();
   useAccountBalances();
+  useTotalBalances();
 
   useEffect(() => {
     const loadContracts = async () => {

--- a/client/pages/vote-escrow.tsx
+++ b/client/pages/vote-escrow.tsx
@@ -1,5 +1,5 @@
-import { ethers, BigNumber } from "ethers";
-import { useEffect, useState } from "react";
+import { ethers } from "ethers";
+import { useState } from "react";
 import { useStore } from "utils/store";
 import { PageTitle } from "components/PageTitle";
 import { Disconnected } from "components/Disconnected";

--- a/client/pages/vote-escrow.tsx
+++ b/client/pages/vote-escrow.tsx
@@ -25,7 +25,13 @@ export async function getServerSideProps({ res }: { res: any }) {
     "public, s-maxage=60, stale-while-revalidate=59"
   );
 
-  const lockups = await prisma.lockup.findMany();
+  const lockups = await prisma.lockup.findMany({
+    where: {
+      active: {
+        equals: true,
+      },
+    },
+  });
   const lockupCount = lockups.length;
   const totalLockupWeeks = lockups.reduce(
     (total: Number, lockup: Object) => total + lockup.weeks,

--- a/client/pages/vote-escrow.tsx
+++ b/client/pages/vote-escrow.tsx
@@ -12,6 +12,7 @@ import { truncateBalance, useNetworkInfo } from "utils/index";
 import { toast } from "react-toastify";
 import useAccountBalances from "utils/useAccountBalances";
 import TokenAmount from "components/TokenAmount";
+import LockupStats from "components/vote-escrow/LockupStats";
 
 const MAX_WEEKS = 52 * 4;
 
@@ -287,6 +288,7 @@ export default function VoteEscrow({}) {
             </div>
           </div>
         </Card>
+        <LockupStats />
       </CardGroup>
     </>
   );

--- a/client/pages/vote-escrow.tsx
+++ b/client/pages/vote-escrow.tsx
@@ -8,7 +8,7 @@ import Card from "components/Card";
 import CardLabel from "components/CardLabel";
 import CardStat from "components/CardStat";
 import CardDescription from "components/CardDescription";
-import { truncateBalance, useNetworkInfo } from "utils/index";
+import { useNetworkInfo } from "utils/index";
 import { toast } from "react-toastify";
 import useAccountBalances from "utils/useAccountBalances";
 import TokenAmount from "components/TokenAmount";

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -34,3 +34,13 @@ model Listener {
 
     @@map("listener")
 }
+
+model Lockup {
+  id       Int @default(autoincrement()) @id
+  address  String @unique
+  amount   String
+  end      String
+  weeks    Int @default(0)
+
+  @@map("lockups")
+}

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -37,10 +37,11 @@ model Listener {
 
 model Lockup {
   id       Int @default(autoincrement()) @id
-  address  String @unique
+  address  String
   amount   String
   end      String
   weeks    Int
+  active   Boolean @default(true)
 
   @@map("lockups")
 }

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Lockup {
   address  String @unique
   amount   String
   end      String
-  weeks    Int @default(0)
+  weeks    Int
 
   @@map("lockups")
 }

--- a/client/utils/store.tsx
+++ b/client/utils/store.tsx
@@ -42,7 +42,6 @@ const defaultState: Web3DataType = {
   pendingTransactions: [],
   totalBalances: {
     totalSupply: ethers.BigNumber.from("0"),
-    lockedUpSupply: ethers.BigNumber.from("0"),
   },
 };
 

--- a/client/utils/store.tsx
+++ b/client/utils/store.tsx
@@ -7,7 +7,11 @@ type Web3DataType = {
   address?: string;
   chainId?: number;
   contracts: Object;
+  balances: Object;
+  existingLockup: Object;
+  allowances: Object;
   pendingTransactions: Array<any>;
+  totalBalances: Object;
 };
 
 type StoreType = Web3DataType & {
@@ -36,6 +40,10 @@ const defaultState: Web3DataType = {
     ogv: ethers.BigNumber.from("0"),
   },
   pendingTransactions: [],
+  totalBalances: {
+    totalSupply: ethers.BigNumber.from("0"),
+    lockedUpSupply: ethers.BigNumber.from("0"),
+  },
 };
 
 export const useStore = create<StoreType>((set) => ({

--- a/client/utils/useTotalBalances.tsx
+++ b/client/utils/useTotalBalances.tsx
@@ -4,27 +4,22 @@ import { useNetworkInfo } from "utils/index";
 
 const useTotalBalances = () => {
   const networkInfo = useNetworkInfo();
-  const { web3Provider, address, contracts } = useStore();
+  const { web3Provider, contracts } = useStore();
 
   useEffect(() => {
     const loadTotalSupply = async () =>
       await contracts.OriginDollarGovernance.totalSupply();
-    const loadLockedUpSupply = async () =>
-      await contracts.VoteLockerCurve.balanceOf(address);
 
-    if (web3Provider && address && networkInfo.correct && contracts.loaded) {
-      Promise.all([loadTotalSupply(), loadLockedUpSupply()]).then(
-        ([totalSupply, lockedUpSupply]) => {
-          useStore.setState({
-            totalBalances: {
-              totalSupply,
-              lockedUpSupply,
-            },
-          });
-        }
-      );
+    if (web3Provider && networkInfo.correct && contracts.loaded) {
+      Promise.all([loadTotalSupply()]).then(([totalSupply]) => {
+        useStore.setState({
+          totalBalances: {
+            totalSupply,
+          },
+        });
+      });
     }
-  }, [networkInfo, web3Provider, address, contracts]);
+  }, [networkInfo, web3Provider, contracts]);
 };
 
 export default useTotalBalances;

--- a/client/utils/useTotalBalances.tsx
+++ b/client/utils/useTotalBalances.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { useStore } from "utils/store";
+import { useNetworkInfo } from "utils/index";
+
+const useTotalBalances = () => {
+  const networkInfo = useNetworkInfo();
+  const { web3Provider, address, contracts } = useStore();
+
+  useEffect(() => {
+    const loadTotalSupply = async () =>
+      await contracts.OriginDollarGovernance.totalSupply();
+    const loadLockedUpSupply = async () =>
+      await contracts.VoteLockerCurve.balanceOf(address);
+
+    if (web3Provider && address && networkInfo.correct && contracts.loaded) {
+      Promise.all([loadTotalSupply(), loadLockedUpSupply()]).then(
+        ([totalSupply, lockedUpSupply]) => {
+          useStore.setState({
+            totalBalances: {
+              totalSupply,
+              lockedUpSupply,
+            },
+          });
+        }
+      );
+    }
+  }, [networkInfo, web3Provider, address, contracts]);
+};
+
+export default useTotalBalances;


### PR DESCRIPTION
Addresses #76.

Adds a lockups table to the database and listens for Ethereum events to populate lockup data when added/amended. This lets us calculate the total supply of OGV locked up and the average lockup length in weeks.

Includes front-end UI as shown in the screenshot below:

![Screenshot 2022-05-04 at 14 58 20](https://user-images.githubusercontent.com/2827412/166697760-fb3658cd-4dcb-4161-8106-ce8e8cb437a8.png)


 