### PR TITLE
Upgradable OGV staking contracts

### DIFF
--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -10,9 +10,9 @@ import {RewardsSource} from "./RewardsSource.sol";
 /// @author Daniel Von Fange
 /// @notice Provides staking, vote power history, vote delegation, and rewards
 /// distribution.
-/// 
+///
 /// The balance received for staking (and thus the voting power and rewards
-/// distribution) goes up exponentially by the end of the staked period. 
+/// distribution) goes up exponentially by the end of the staked period.
 contract OgvStaking is ERC20Votes {
     // 1. Core Storage
     uint256 public immutable epoch;
@@ -28,7 +28,7 @@ contract OgvStaking is ERC20Votes {
 
     // 3. Reward Storage
     ERC20 public immutable ogv; // Must not allow reentrancy
-    RewardsSource public rewardsSource;
+    RewardsSource public immutable rewardsSource;
     mapping(address => uint256) public rewardDebtPerShare;
     uint256 public accRewardPerShare; // As of the start of the block
 
@@ -111,14 +111,11 @@ contract OgvStaking is ERC20Votes {
     /// epoch.
     ///
     /// Any rewards previously earned will be paid out.
-    /// 
+    ///
     /// @notice Stake OGV for myself.
     /// @param amount OGV to lockup in the stake
     /// @param duration in seconds for the stake
-    function stake(
-        uint256 amount,
-        uint256 duration
-    ) external {
+    function stake(uint256 amount, uint256 duration) external {
         _stake(amount, duration, msg.sender);
     }
 
@@ -173,9 +170,9 @@ contract OgvStaking is ERC20Votes {
     ///
     /// The stake end time is computed from the current time + duration, just
     /// like it is for new stakes. So a new stake for seven days duration and
-    /// an old stake extended with a seven days duration would have the same 
+    /// an old stake extended with a seven days duration would have the same
     /// end.
-    /// 
+    ///
     /// If an extend is made before the start of staking, the start time for
     /// the new stake is shifted forwards to the start of staking, which also
     /// shifts forward the end date.
@@ -234,7 +231,7 @@ contract OgvStaking is ERC20Votes {
     /// rewards at this time.
     ///
     /// @param user to preview rewards for
-    /// @return OGV rewards amount 
+    /// @return OGV rewards amount
     function previewRewards(address user) external view returns (uint256) {
         uint256 supply = totalSupply();
         if (supply == 0) {
@@ -248,7 +245,7 @@ contract OgvStaking is ERC20Votes {
     }
 
     /// @dev Internal function to handle rewards accounting.
-    /// 
+    ///
     /// 1. Collect new rewards for everyone
     /// 2. Calculate this user's rewards and accounting
     /// 3. Distribute this user's rewards
@@ -257,7 +254,7 @@ contract OgvStaking is ERC20Votes {
     ///
     /// This will always update the user's rewardDebtPerShare to match
     /// accRewardPerShare, which is essential to the accounting.
-    /// 
+    ///
     /// @param user to collect rewards for
     function _collectRewards(address user) internal {
         uint256 supply = totalSupply();

--- a/contracts/upgrades/InitializeGovernedUpgradeabilityProxy.sol
+++ b/contracts/upgrades/InitializeGovernedUpgradeabilityProxy.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.8.0;
+
+import {Address} from "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/utils/Address.sol";
+
+import {Governable} from "../Governable.sol";
+
+/**
+ * @title BaseGovernedUpgradeabilityProxy
+ * @dev This contract combines an upgradeability proxy with our governor system.
+ * It is based on an older version of OpenZeppelins BaseUpgradeabilityProxy
+ * with Solidity ^0.8.0.
+ * @author Origin Protocol Inc
+ */
+contract InitializeGovernedUpgradeabilityProxy is Governable {
+    /**
+     * @dev Emitted when the implementation is upgraded.
+     * @param implementation Address of the new implementation.
+     */
+    event Upgraded(address indexed implementation);
+
+    /**
+     * @dev Contract initializer with Governor enforcement
+     * @param _logic Address of the initial implementation.
+     * @param _initGovernor Address of the initial Governor.
+     * @param _data Data to send as msg.data to the implementation to initialize
+     * the proxied contract.
+     * It should include the signature and the parameters of the function to be
+     * called, as described in
+     * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+     * This parameter is optional, if no data is given the initialization call
+     * to proxied contract will be skipped.
+     */
+    function initialize(
+        address _logic,
+        address _initGovernor,
+        bytes memory _data
+    ) public payable onlyGovernor {
+        require(_implementation() == address(0));
+        assert(
+            IMPLEMENTATION_SLOT ==
+                bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
+        );
+        _changeGovernor(_initGovernor);
+        _setImplementation(_logic);
+        if (_data.length > 0) {
+            (bool success, ) = _logic.delegatecall(_data);
+            require(success);
+        }
+    }
+
+    /**
+     * @return The address of the proxy admin/it's also the governor.
+     */
+    function admin() external view returns (address) {
+        return _governor();
+    }
+
+    /**
+     * @return The address of the implementation.
+     */
+    function implementation() external view returns (address) {
+        return _implementation();
+    }
+
+    /**
+     * @dev Upgrade the backing implementation of the proxy.
+     * Only the admin can call this function.
+     * @param newImplementation Address of the new implementation.
+     */
+    function upgradeTo(address newImplementation) external onlyGovernor {
+        _upgradeTo(newImplementation);
+    }
+
+    /**
+     * @dev Upgrade the backing implementation of the proxy and call a function
+     * on the new implementation.
+     * This is useful to initialize the proxied contract.
+     * @param newImplementation Address of the new implementation.
+     * @param data Data to send as msg.data in the low level call.
+     * It should include the signature and the parameters of the function to be called, as described in
+     * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
+     */
+    function upgradeToAndCall(address newImplementation, bytes calldata data)
+        external
+        payable
+        onlyGovernor
+    {
+        _upgradeTo(newImplementation);
+        (bool success, ) = newImplementation.delegatecall(data);
+        require(success);
+    }
+
+    /**
+     * @dev Fallback function.
+     * Implemented entirely in `_fallback`.
+     */
+    fallback() external payable {
+        _fallback();
+    }
+
+    /**
+     * @dev Delegates execution to an implementation contract.
+     * This is a low level function that doesn't return to its internal call site.
+     * It will return to the external caller whatever the implementation returns.
+     * @param _impl Address to delegate.
+     */
+    function _delegate(address _impl) internal {
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), _impl, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @dev Function that is run as the first thing in the fallback function.
+     * Can be redefined in derived contracts to add functionality.
+     * Redefinitions must call super._willFallback().
+     */
+    function _willFallback() internal {}
+
+    /**
+     * @dev fallback implementation.
+     * Extracted to enable manual triggering.
+     */
+    function _fallback() internal {
+        _willFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     */
+    bytes32 internal constant IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /**
+     * @dev Returns the current implementation.
+     * @return impl Address of the current implementation
+     */
+    function _implementation() internal view returns (address impl) {
+        bytes32 slot = IMPLEMENTATION_SLOT;
+        assembly {
+            impl := sload(slot)
+        }
+    }
+
+    /**
+     * @dev Upgrades the proxy to a new implementation.
+     * @param newImplementation Address of the new implementation.
+     */
+    function _upgradeTo(address newImplementation) internal {
+        _setImplementation(newImplementation);
+        emit Upgraded(newImplementation);
+    }
+
+    /**
+     * @dev Sets the implementation address of the proxy.
+     * @param newImplementation Address of the new implementation.
+     */
+    function _setImplementation(address newImplementation) internal {
+        require(
+            Address.isContract(newImplementation),
+            "Cannot set a proxy implementation to a non-contract address"
+        );
+
+        bytes32 slot = IMPLEMENTATION_SLOT;
+
+        assembly {
+            sstore(slot, newImplementation)
+        }
+    }
+}

--- a/contracts/upgrades/OgvStakingProxy.sol
+++ b/contracts/upgrades/OgvStakingProxy.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import {InitializeGovernedUpgradeabilityProxy} from "./InitializeGovernedUpgradeabilityProxy.sol";
+
+contract OgvStakingProxy is InitializeGovernedUpgradeabilityProxy {}

--- a/contracts/upgrades/RewardsSourceProxy.sol
+++ b/contracts/upgrades/RewardsSourceProxy.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import {InitializeGovernedUpgradeabilityProxy} from "./InitializeGovernedUpgradeabilityProxy.sol";
+
+contract RewardsSourceProxy is InitializeGovernedUpgradeabilityProxy {}

--- a/tests/staking/OgvStaking.t.sol
+++ b/tests/staking/OgvStaking.t.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.10;
 
 import "forge-std/Test.sol";
+import "../../contracts/upgrades/RewardsSourceProxy.sol";
+import "../../contracts/upgrades/OgvStakingProxy.sol";
 import "../../contracts/OgvStaking.sol";
 import "../../contracts/RewardsSource.sol";
 import "../../contracts/tests/MockOgv.sol";
@@ -21,7 +23,16 @@ contract OgvStakingTest is Test {
         vm.startPrank(team);
         ogv = new MockOgv();
         source = new RewardsSource(address(ogv));
+
+        RewardsSourceProxy rewardsProxy = new RewardsSourceProxy();
+        rewardsProxy.initialize(address(source), team, '');
+        source = RewardsSource(address(rewardsProxy));
+
         staking = new OgvStaking(address(ogv), EPOCH, address(source));
+        OgvStakingProxy stakingProxy = new OgvStakingProxy();
+        stakingProxy.initialize(address(staking), team, '');
+        staking = OgvStaking(address(stakingProxy));
+
         source.setRewardsTarget(address(staking));
         vm.stopPrank();
 


### PR DESCRIPTION
Upgradable contracts for OGV staking.

Notes:

Uses proxy code from OUSD. I much prefer this style - with upgrade logic in the proxy - over UUPS proxies.

No contract specific initializers needed, just initialize the the proxies to point at the base contracts, and we are good to go.

I've changed the forge tests and the brownie tests over to use the proxies as part of the testing.


