### PR TITLE
Configurable minimum staking duration

### DIFF
--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -16,6 +16,7 @@ import {RewardsSource} from "./RewardsSource.sol";
 contract OgvStaking is ERC20Votes {
     // 1. Core Storage
     uint256 public immutable epoch;
+    uint256 public immutable minStakeDuration;
 
     // 2. Staking and Lockup Storage
     uint256 constant YEAR_BASE = 18e17;
@@ -54,10 +55,12 @@ contract OgvStaking is ERC20Votes {
     constructor(
         address ogv_,
         uint256 epoch_,
+        uint256 minStakeDuration_,
         address rewardsSource_
     ) ERC20("", "") ERC20Permit("veOGV") {
         ogv = ERC20(ogv_);
         epoch = epoch_;
+        minStakeDuration = minStakeDuration_;
         rewardsSource = RewardsSource(rewardsSource_);
     }
 
@@ -214,7 +217,7 @@ contract OgvStaking is ERC20Votes {
         view
         returns (uint256, uint256)
     {
-        require(duration >= 7 days, "Staking: Too short");
+        require(duration >= minStakeDuration, "Staking: Too short");
         require(duration <= 1461 days, "Staking: Too long");
         uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
         uint256 end = start + duration;

--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -15,8 +15,8 @@ import {RewardsSource} from "./RewardsSource.sol";
 /// distribution) goes up exponentially by the end of the staked period. 
 contract OgvStaking is ERC20Votes {
     // 1. Core Storage
-    uint256 public immutable epoch;
-    uint256 public immutable minStakeDuration;
+    uint256 public immutable epoch; // timestamp
+    uint256 public immutable minStakeDuration; // in seconds
 
     // 2. Staking and Lockup Storage
     uint256 constant YEAR_BASE = 18e17;

--- a/scripts/deploy_staking.py
+++ b/scripts/deploy_staking.py
@@ -2,6 +2,7 @@ from brownie import *
 
 
 def main(token_address, epoch, rewards_address):
-    staking_impl = OgvStaking.deploy(token_address, epoch, rewards_address)
+    min_staking = 7 * 24 * 60 * 60
+    staking_impl = OgvStaking.deploy(token_address, epoch, min_staking, rewards_address)
     # @TODO Proxy for staking implementation contract
     return Contract.from_abi("OgvStaking", staking_impl.address, staking_impl.abi)

--- a/tests/staking/DelegationTest.t.sol
+++ b/tests/staking/DelegationTest.t.sol
@@ -28,7 +28,7 @@ contract DelegationTest is Test {
         vm.startPrank(team);
         ogv = new MockOgv();
         source = new RewardsSource(address(ogv));
-        staking = new OgvStaking(address(ogv), EPOCH, address(source));
+        staking = new OgvStaking(address(ogv), EPOCH, 7 days, address(source));
         source.setRewardsTarget(address(staking));
         vm.stopPrank();
 

--- a/tests/staking/OgvStaking.t.sol
+++ b/tests/staking/OgvStaking.t.sol
@@ -16,12 +16,13 @@ contract OgvStakingTest is Test {
     address team = address(0x44);
 
     uint256 constant EPOCH = 1 days;
+    uint256 constant MIN_STAKE_DURATION = 7 days;
 
     function setUp() public {
         vm.startPrank(team);
         ogv = new MockOgv();
         source = new RewardsSource(address(ogv));
-        staking = new OgvStaking(address(ogv), EPOCH, address(source));
+        staking = new OgvStaking(address(ogv), EPOCH, MIN_STAKE_DURATION, address(source));
         source.setRewardsTarget(address(staking));
         vm.stopPrank();
 
@@ -127,7 +128,7 @@ contract OgvStakingTest is Test {
     function testStakeTooShort() public {
         vm.prank(alice);
         vm.expectRevert("Staking: Too short");
-        staking.stake(1 ether, 1 days, alice);
+        staking.stake(1 ether, 6 days, alice);
     }
 
     function testExtend() public {


### PR DESCRIPTION
Allows minimum staking time to be changed at contract deploy time.

Keeps  minimum staking time to seven days in tests, so that we don't have to redo all our math and tests.