### PR TITLE
start refactoring contracts setup

### DIFF
--- a/client/components/proposal/AddActionContractForm.tsx
+++ b/client/components/proposal/AddActionContractForm.tsx
@@ -46,18 +46,18 @@ export const AddActionContractForm = ({
 
   useEffect(() => {
     if (values.address.length === 42) {
-      const contract = Object.values(contracts).find(
-        (c) => c.address === values.address
+      const contractObj = Object.values(contracts).find(
+        (c) => c.impl.address === values.address
       );
 
-      if (contract) {
+      if (contractObj) {
         changeHandler({
           target: {
             name: "abi",
-            value: contract.abi,
+            value: contractObj.abi,
           },
         });
-        onChange(contract);
+        onChange(contractObj);
       }
     }
   }, [values.address]);
@@ -122,8 +122,11 @@ export const AddActionContractForm = ({
                 {Object.entries(contracts)
                   .filter(([name, contract]) => typeof contract === "object")
                   .map(([name, contract]) => (
-                    <option key={contract.address} value={contract.address}>
-                      {name} {truncateEthAddress(contract.address)}
+                    <option
+                      key={contract.impl.address}
+                      value={contract.impl.address}
+                    >
+                      {name} {truncateEthAddress(contract.impl.address)}
                     </option>
                   ))}
               </select>

--- a/client/components/proposal/ProposalActionAddModal.tsx
+++ b/client/components/proposal/ProposalActionAddModal.tsx
@@ -36,6 +36,7 @@ export const ProposalActionAddModal = ({
     setImplementationAddress("");
   };
 
+  console.log("Conracts", contracts);
   return (
     <div
       id="proposal-add-modal"
@@ -51,7 +52,9 @@ export const ProposalActionAddModal = ({
         {step === 0 && (
           <AddActionContractForm
             onChange={async (contract: any) => {
-              const { abi, address } = contract;
+              const { abi, impl } = contract;
+              const address = impl.address;
+
               // Check contract selected abi for implementation method
               const implementationFunction = abi.find(
                 ({ type, name }: { type: string; name: string }) =>

--- a/client/networks/governance.localhost.json
+++ b/client/networks/governance.localhost.json
@@ -1012,6 +1012,11 @@
             "type": "uint256"
           },
           {
+            "internalType": "uint256",
+            "name": "minStakeDuration_",
+            "type": "uint256"
+          },
+          {
             "internalType": "address",
             "name": "rewardsSource_",
             "type": "address"
@@ -1635,6 +1640,19 @@
           {
             "internalType": "uint256",
             "name": "points",
+            "type": "uint256"
+          }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "minStakeDuration",
+        "outputs": [
+          {
+            "internalType": "uint256",
+            "name": "",
             "type": "uint256"
           }
         ],

--- a/client/pages/proposal/new.tsx
+++ b/client/pages/proposal/new.tsx
@@ -34,7 +34,7 @@ const ProposalNew: NextPage = () => {
 
   useEffect(() => {
     const loadProposalThreshold = async () => {
-      setProposalThreshold(await contracts.Governance.proposalThreshold());
+      setProposalThreshold(await contracts.Governance.impl.proposalThreshold());
     };
     if (contracts.loaded) {
       loadProposalThreshold();
@@ -44,7 +44,7 @@ const ProposalNew: NextPage = () => {
   // Load users vote power
   useEffect(() => {
     const loadVotePower = async () => {
-      const votePower = await contracts.VoteLockerCurve.balanceOf(address);
+      const votePower = await contracts.VoteLockerCurve.impl.balanceOf(address);
       setVotePower(votePower);
     };
     if (web3Provider && address && contracts.loaded) {
@@ -88,7 +88,7 @@ const ProposalNew: NextPage = () => {
     let transaction;
 
     try {
-      transaction = await contracts.Governance[
+      transaction = await contracts.impl.Governance[
         "propose(address[],uint256[],string[],bytes[],string)"
       ](
         proposalActions.targets,

--- a/client/utils/store.tsx
+++ b/client/utils/store.tsx
@@ -27,6 +27,8 @@ const defaultState: Web3DataType = {
   contracts: {
     loaded: false,
   },
+  contractsAbi: {},
+  rpcProvider: null,
   balances: {
     ogv: ethers.BigNumber.from("0"),
     veOgv: ethers.BigNumber.from("0"),

--- a/client/utils/useAccountBalances.js
+++ b/client/utils/useAccountBalances.js
@@ -12,11 +12,11 @@ const useAccountBalances = () => {
   // Load users governance token balance and vote power
   useEffect(() => {
     const loadOgvBalance = async () => {
-      return await contracts.OriginDollarGovernance.balanceOf(address);
+      return await contracts.OriginDollarGovernance.impl.balanceOf(address);
     };
 
     const loadVeOgvBalance = async () => {
-      return await contracts.OgvStaking.balanceOf(address);
+      return await contracts.OgvStaking.impl.balanceOf(address);
     };
 
     if (
@@ -51,9 +51,9 @@ const useAccountBalances = () => {
 
   useEffect(() => {
     const loadAllowance = async () => {
-      return await contracts.OriginDollarGovernance.allowance(
+      return await contracts.OriginDollarGovernance.impl.allowance(
         address,
-        contracts.OgvStaking.address
+        contracts.OgvStaking.impl.address
       );
     };
 

--- a/client/utils/useClaim.tsx
+++ b/client/utils/useClaim.tsx
@@ -16,7 +16,7 @@ const useClaim = () => {
   const [totalSupplyVeOgv, setTotalSupplyVeOgv] = useState(null);
   const [totalSupplyVeOgvAdjusted, setTotalSupplyVeOgvAdjusted] =
     useState(null);
-  const { address, contracts, web3Provider } = useStore();
+  const { address, contracts, web3Provider, rpcProvider } = useStore();
   const hasClaim = claim.optional.hasClaim || claim.mandatory.hasClaim;
   /*
    * ready -> ready to start claiming
@@ -70,7 +70,7 @@ const useClaim = () => {
   useEffect(() => {
     if (
       !contracts.loaded ||
-      !(claim.optional.hasClaim || claim.mandatory.hasClaim)
+      !(claim.optional.impl.hasClaim || claim.mandatory.impl.hasClaim)
     ) {
       return;
     }
@@ -100,7 +100,7 @@ const useClaim = () => {
 
         if (claim.optional.hasClaim) {
           let distributor = await readDistributor(
-            contracts.OptionalDistributor,
+            contracts.OptionalDistributor.impl,
             claim.optional,
             setOptionalClaimState
           );
@@ -120,7 +120,7 @@ const useClaim = () => {
               try {
                 claimResult = await (
                   await useConnectSigner(
-                    contracts.OptionalDistributor,
+                    contracts.OptionalDistributor.impl,
                     web3Provider
                   )
                 )["claim(uint256,uint256,bytes32[],uint256)"](
@@ -138,7 +138,7 @@ const useClaim = () => {
               setOptionalClaimState("waiting-for-network");
               let receipt;
               try {
-                receipt = await contracts.rpcProvider.waitForTransaction(
+                receipt = await rpcProvider.waitForTransaction(
                   claimResult.hash
                 );
                 // sleep for 5 seconds on development so it is more noticeable
@@ -157,7 +157,7 @@ const useClaim = () => {
 
         if (claim.mandatory.hasClaim) {
           let distributor = await readDistributor(
-            contracts.MandatoryDistributor,
+            contracts.MandatoryDistributor.impl,
             claim.mandatory,
             setMandatoryClaimState
           );
@@ -170,7 +170,7 @@ const useClaim = () => {
               try {
                 claimResult = await (
                   await useConnectSigner(
-                    contracts.MandatoryDistributor,
+                    contracts.MandatoryDistributor.impl,
                     web3Provider
                   )
                 )["claim(uint256,uint256,bytes32[])"](
@@ -187,7 +187,7 @@ const useClaim = () => {
               setMandatoryClaimState("waiting-for-network");
               let receipt;
               try {
-                receipt = await contracts.rpcProvider.waitForTransaction(
+                receipt = await rpcProvider.waitForTransaction(
                   claimResult.hash
                 );
                 // sleep for 5 seconds on development so it is more noticeable
@@ -221,7 +221,7 @@ const useClaim = () => {
         return;
       }
       try {
-        const totalSupplyBn = await contracts.OgvStaking.totalSupply();
+        const totalSupplyBn = await contracts.impl.OgvStaking.totalSupply();
         setTotalSupplyVeOgv(totalSupplyBn);
         // TODO: verify this that we need to set some minimal total supply. Otherwise the first couple
         // of claimers will see insane reward amounts

--- a/client/utils/useContracts.tsx
+++ b/client/utils/useContracts.tsx
@@ -47,7 +47,10 @@ const useContracts = () => {
           signer || provider
         );
         return {
-          [name]: contract,
+          [name]: {
+            impl: contract,
+            abi: definition.abi,
+          },
         };
       });
 
@@ -58,8 +61,12 @@ const useContracts = () => {
             definition.abi,
             mainnetProvider
           );
+
           return {
-            [name]: contract,
+            [name]: {
+              impl: contract,
+              abi: definition.abi,
+            },
           };
         }
       );
@@ -69,9 +76,9 @@ const useContracts = () => {
       );
 
       contracts.loaded = true;
-      contracts.rpcProvider = networkProvider;
       useStore.setState({
         contracts,
+        rpcProvider: networkProvider,
       });
     };
     if (claimIsOpen()) {

--- a/client/utils/useTotalBalances.tsx
+++ b/client/utils/useTotalBalances.tsx
@@ -10,11 +10,11 @@ const useTotalBalances = () => {
 
   useEffect(() => {
     const loadTotalSupplyOfOgv = async () =>
-      await contracts.OriginDollarGovernance.totalSupply();
+      await contracts.OriginDollarGovernance.impl.totalSupply();
 
     const loadTotalLockedUpOgv = async () =>
-      await contracts.OriginDollarGovernance.balanceOf(
-        contracts.OgvStaking.address
+      await contracts.OriginDollarGovernance.impl.balanceOf(
+        contracts.OgvStaking.impl.address
       );
 
     if (


### PR DESCRIPTION
Creating proposals is broken right now because of my change some time ago how contracts are setup. Previously contracts object was deconstructed and `abi` property was added to the contract. Which is very convenient to tie together abi + contract functionality. But it is not a perfect copy since it does not copy over things like `connect` function that allows to connect a signer. 

For that reason in this PR the contract object now separately contains contract and abi implementation.