### PR TITLE
Listener: user WEB3_PROVIDER vs hardcoded value

### DIFF
--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -2,14 +2,9 @@ import LocalGovernanceContracts from "../networks/governance.localhost.json";
 import RinkebyGovernanceContracts from "../networks/governance.rinkeby.json";
 import MainnetGovernanceContracts from "../networks/governance.mainnet.json";
 
-export const INFURA_ID = "460f40a260564ac4a4f4b3fffb032dad";
-export const mainnetNetworkUrl = `https://mainnet.infura.io/v3/${INFURA_ID}`;
-export const rinkebyNetworkUrl =
-  "https://eth-rinkeby.alchemyapi.io/v2/i4XEfcs5ZohhedGPYPK72GBrz6mBpjAP";
-
 export const RPC_URLS = {
-  1: mainnetNetworkUrl,
-  4: rinkebyNetworkUrl,
+  1: process.env.WEB3_PROVIDER,
+  4: process.env.WEB3_PROVIDER,
   31337: "http://localhost:8545",
 };
 


### PR DESCRIPTION
I double checked and there is an env var WEB3_PROVIDER defined in heroku both for the Rinkeby and Mainnet deploys.