### PR TITLE
Fix missing imports

### DIFF
--- a/client/components/Web3Button.tsx
+++ b/client/components/Web3Button.tsx
@@ -5,7 +5,7 @@ import WalletLink from "walletlink";
 import Web3Modal from "web3modal";
 import { truncateEthAddress, useNetworkInfo } from "utils/index";
 import { useStore } from "utils/store";
-import { INFURA_ID, mainnetNetworkUrl } from "constants/index";
+import { RPC_URLS, mainnetNetworkUrl } from "constants/index";
 import { toast } from "react-toastify";
 import classNames from "classnames";
 
@@ -13,7 +13,7 @@ const providerOptions = {
   walletconnect: {
     package: WalletConnectProvider, // required
     options: {
-      infuraId: INFURA_ID, // required
+      rpc: RPC_URLS
     },
   },
   "custom-walletlink": {

--- a/client/constants/index.ts
+++ b/client/constants/index.ts
@@ -2,9 +2,12 @@ import LocalGovernanceContracts from "../networks/governance.localhost.json";
 import RinkebyGovernanceContracts from "../networks/governance.rinkeby.json";
 import MainnetGovernanceContracts from "../networks/governance.mainnet.json";
 
+export const mainnetNetworkUrl = process.env.WEB3_PROVIDER;
+export const rinkebyNetworkUrl = process.env.WEB3_PROVIDER;
+
 export const RPC_URLS = {
-  1: process.env.WEB3_PROVIDER,
-  4: process.env.WEB3_PROVIDER,
+  1: mainnetNetworkUrl,
+  4: rinkebyNetworkUrl,
   31337: "http://localhost:8545",
 };
 


### PR DESCRIPTION
I broke the build with #152 since I did not realize INFURA_ID, mainnetNetworkUrl and rinkebyNetworkUrl were used elsewhere.

This PR re-introduces mainnetNetworkUrl and rinkebyNetworkUrl but still gets rid of INFURA_ID since really I'd prefer to not have these keys committed in the code.

The docs for WalletConnect are here: https://docs.walletconnect.com/quick-start/dapps/web3-provider#required and it looks like it support either InfuraId or an rpc mapping.