### PR TITLE
Flicker to loader

### DIFF
--- a/client/components/Web3Button.tsx
+++ b/client/components/Web3Button.tsx
@@ -1,5 +1,5 @@
 import WalletConnectProvider from "@walletconnect/web3-provider";
-import { providers } from "ethers";
+import { providers, utils } from "ethers";
 import { useCallback, useEffect, FunctionComponent } from "react";
 import WalletLink from "walletlink";
 import Web3Modal from "web3modal";
@@ -89,7 +89,7 @@ export const Web3Button: FunctionComponent<Web3ButtonProps> = ({ inPage }) => {
       const newAccount: string =
         accounts.length === 0 ? undefined : accounts[0];
       let storeUpdate = {
-        address: newAccount,
+        address: utils.getAddress(newAccount), // ensure checksum address to prevent excess state updates
       };
       resetWeb3State();
 

--- a/client/components/claim/Eligibility.tsx
+++ b/client/components/claim/Eligibility.tsx
@@ -18,10 +18,10 @@ const Eligibility: FunctionComponent<EligibilityProps> = ({
 }) => {
   const { provider, web3Provider, address, web3Modal } = useStore();
   const claim = useClaim();
-  const { loaded } = claim;
-  const isEligible = claim.loaded && claim.hasClaim;
+  const { loaded, hasClaim } = claim;
+
   const claimValid =
-    (isEligible && claim.optional && claim.optional.isValid) ||
+    (hasClaim && claim.optional && claim.optional.isValid) ||
     (claim.mandatory && claim.mandatory.isValid);
 
   const resetWeb3State = useStore((state) => state.reset);
@@ -37,10 +37,12 @@ const Eligibility: FunctionComponent<EligibilityProps> = ({
     [web3Modal, provider, resetWeb3State]
   );
 
-  if (!address || !loaded) {
+  if (web3Provider && !loaded) {
     return (
       <Card>
-        <Loading large />
+        <div className="py-20">
+          <Loading large />
+        </div>
       </Card>
     );
   }
@@ -65,7 +67,7 @@ const Eligibility: FunctionComponent<EligibilityProps> = ({
             </div>
           ) : (
             <>
-              {isEligible ? (
+              {hasClaim ? (
                 <div className="space-y-2">
                   {claimValid ? (
                     <div className="mb-20">
@@ -153,7 +155,7 @@ const Eligibility: FunctionComponent<EligibilityProps> = ({
               )}
             </>
           )}
-          {isEligible && claimValid && (
+          {hasClaim && claimValid && (
             <div className="space-y-2">
               <table className="table w-full mt-6">
                 <thead>

--- a/client/components/claim/Eligibility.tsx
+++ b/client/components/claim/Eligibility.tsx
@@ -1,14 +1,13 @@
 import { FunctionComponent, useCallback } from "react";
-import Image from "next/image";
 import Card from "components/Card";
 import { Web3Button } from "components/Web3Button";
 import Button from "components/Button";
 import { useStore } from "utils/store";
-import { truncateEthAddress } from "utils/index";
 import useClaim from "utils/useClaim";
 import EligibilityItem from "components/claim/EligibilityItem";
 import Icon from "@mdi/react";
 import { mdiWallet, mdiCheckCircle, mdiAlertCircle } from "@mdi/js";
+import { Loading } from "components/Loading";
 
 interface EligibilityProps {
   handleNextStep: () => void;
@@ -19,6 +18,7 @@ const Eligibility: FunctionComponent<EligibilityProps> = ({
 }) => {
   const { provider, web3Provider, address, web3Modal } = useStore();
   const claim = useClaim();
+  const { loaded } = claim;
   const isEligible = claim.loaded && claim.hasClaim;
   const claimValid =
     (isEligible && claim.optional && claim.optional.isValid) ||
@@ -37,7 +37,13 @@ const Eligibility: FunctionComponent<EligibilityProps> = ({
     [web3Modal, provider, resetWeb3State]
   );
 
-  const canAdvance = web3Provider && isEligible;
+  if (!address || !loaded) {
+    return (
+      <Card>
+        <Loading large />
+      </Card>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
- Adds loader component when claim data is being fetched (initially and on account switch)
- Added changed to web3 state to ensure checksum address is added to prevent unneeded state changes (was contributing to the flicker we were experiencing)

Addresses: #129 