### PR TITLE
Timer polish / Admin tools

### DIFF
--- a/client/components/AdminUtils.js
+++ b/client/components/AdminUtils.js
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+import { useStore } from "utils/store";
+
+const AdminUtils = () => {
+  const show = useMemo(() => {
+    if (process.browser) {
+      if (localStorage.getItem("admin") === "true") {
+        return true;
+      }
+    }
+    return false;
+  }, [process.browser]);
+
+  const setClaimsOpenTs = (claimOpensTs) => {
+    useStore.setState({
+      claim: {
+        claimOpensTs,
+        claimClosesTs: process.env.CLAIM_CLOSES,
+      },
+    });
+  };
+
+  const buttonClass = "px-2 py-1 my-1 border border-black rounded-md";
+  return (
+    show && (
+      <div className="fixed w-34 bottom-0 right-0 bg-gray-300 flex flex-col justify-center">
+        <button
+          className={buttonClass}
+          onClick={() => {
+            setClaimsOpenTs(1);
+          }}
+        >
+          Open claims
+        </button>
+        <button
+          className={buttonClass}
+          onClick={() => {
+            setClaimsOpenTs(Date.now() / 1000 + 5);
+          }}
+        >
+          Open claims in 5s
+        </button>
+        <button
+          className={buttonClass}
+          onClick={() => {
+            setClaimsOpenTs(process.env.CLAIM_OPENS);
+          }}
+        >
+          Reset Open Claims
+        </button>
+      </div>
+    )
+  );
+};
+
+export default AdminUtils;

--- a/client/components/holding/Page.tsx
+++ b/client/components/holding/Page.tsx
@@ -7,6 +7,7 @@ import Card from "../Card";
 import CardDescription from "../CardDescription";
 import CardStat from "../CardStat";
 import ExternalLinkIcon from "../ExternalLinkIcon";
+import { useStore } from "utils/store";
 
 const renderer: CountdownRendererFn = ({ days, hours, minutes, seconds }) => (
   <CardGroup horizontal fourCol dontStackOnMobile>
@@ -29,86 +30,89 @@ const renderer: CountdownRendererFn = ({ days, hours, minutes, seconds }) => (
   </CardGroup>
 );
 
-let date = new Date(0);
-date.setUTCSeconds(parseInt(process.env.CLAIM_OPENS || "0"));
+const HoldingPage = () => {
+  const { claim } = useStore();
+  let date = new Date(0);
+  date.setUTCSeconds(parseInt(claim.claimOpensTs || "0"));
 
-const HoldingPage: FunctionComponent = () => (
-  <>
-    <PageTitle>OGV token launch countdown</PageTitle>
-    <CardGroup>
-      <Countdown date={date} renderer={renderer} />
-      <Card>
-        <SectionTitle>
-          <div className="flex items-center justify-between">
-            <span>Key dates</span>
-            <span className="text-sm text-gray-500 ml-2">
-              All times midnight UTC
-            </span>
-          </div>
-        </SectionTitle>
+  return (
+    <>
+      <PageTitle>OGV token launch countdown</PageTitle>
+      <CardGroup>
+        <Countdown date={date} renderer={renderer} />
+        <Card>
+          <SectionTitle>
+            <div className="flex items-center justify-between">
+              <span>Key dates</span>
+              <span className="text-sm text-gray-500 ml-2">
+                All times midnight UTC
+              </span>
+            </div>
+          </SectionTitle>
 
-        <div className="overflow-scroll">
-          <div className="w-full flex text-left">
-            <div className="divide-y w-full">
-              <div className="flex flex-col pb-2">
-                <div className="font-bold">June 1</div>
-                <div className="text-gray-600">
-                  Prelaunch liquidity mining campaign begins
+          <div className="overflow-scroll">
+            <div className="w-full flex text-left">
+              <div className="divide-y w-full">
+                <div className="flex flex-col pb-2">
+                  <div className="font-bold">June 1</div>
+                  <div className="text-gray-600">
+                    Prelaunch liquidity mining campaign begins
+                  </div>
                 </div>
-              </div>
-              <div className="py-2">
-                <div className="font-bold">June 28</div>
-                <div className="text-gray-600">
-                  Final list of exchanges supporting OGV to be published
+                <div className="py-2">
+                  <div className="font-bold">June 28</div>
+                  <div className="text-gray-600">
+                    Final list of exchanges supporting OGV to be published
+                  </div>
                 </div>
-              </div>
-              <div className="py-2">
-                <div className="font-bold">July 5-12</div>
-                <div className="text-gray-600">OGN snapshot window</div>
-              </div>
-              <div className="py-2">
-                <div className="font-bold">July 12</div>
-                <div className="text-gray-600">OGV airdrop</div>
-              </div>
-              <div className="py-2">
-                <div className="font-bold">October 10</div>
-                <div className="text-gray-600">
-                  90-day deadline to claim airdrop
+                <div className="py-2">
+                  <div className="font-bold">July 5-12</div>
+                  <div className="text-gray-600">OGN snapshot window</div>
+                </div>
+                <div className="py-2">
+                  <div className="font-bold">July 12</div>
+                  <div className="text-gray-600">OGV airdrop</div>
+                </div>
+                <div className="py-2">
+                  <div className="font-bold">October 10</div>
+                  <div className="text-gray-600">
+                    90-day deadline to claim airdrop
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-        <div className="space-y-4 lg:space-y-0 lg:space-x-4 lg:flex mt-6">
+          <div className="space-y-4 lg:space-y-0 lg:space-x-4 lg:flex mt-6">
+            <a
+              className="btn btn-lg btn-primary rounded-full w-full lg:flex-1"
+              href="https://app.uniswap.org/#/swap?outputCurrency=0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26&amp;chain=mainnet"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Buy OGN on Uniswap
+            </a>
+            <a
+              className="btn btn-lg btn-primary rounded-full w-full lg:flex-1"
+              href="https://curve.fi/factory/9/deposit"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Be an OUSD LP
+            </a>
+          </div>
           <a
-            className="btn btn-lg btn-primary rounded-full w-full lg:flex-1"
-            href="https://app.uniswap.org/#/swap?outputCurrency=0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26&amp;chain=mainnet"
+            className="text-sm text-gray-600 mt-6 flex"
+            href="https://blog.originprotocol.com/tokenomics-retroactive-rewards-and-prelaunch-liquidity-mining-campaign-for-ogv-1b20b8ab41c8"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Buy OGN on Uniswap
+            <span className="mr-1">Learn more about the OGV token launch</span>
+            <ExternalLinkIcon />
           </a>
-          <a
-            className="btn btn-lg btn-primary rounded-full w-full lg:flex-1"
-            href="https://curve.fi/factory/9/deposit"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Be an OUSD LP
-          </a>
-        </div>
-        <a
-          className="text-sm text-gray-600 mt-6 flex"
-          href="https://blog.originprotocol.com/tokenomics-retroactive-rewards-and-prelaunch-liquidity-mining-campaign-for-ogv-1b20b8ab41c8"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span className="mr-1">Learn more about the OGV token launch</span>
-          <ExternalLinkIcon />
-        </a>
-      </Card>
-    </CardGroup>
-  </>
-);
+        </Card>
+      </CardGroup>
+    </>
+  );
+};
 
 export default HoldingPage;

--- a/client/components/holding/Page.tsx
+++ b/client/components/holding/Page.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, ReactNode } from "react";
+import { FunctionComponent, ReactNode, useEffect, useState } from "react";
 import Countdown, { CountdownRendererFn } from "react-countdown";
 import { PageTitle } from "../PageTitle";
 import { SectionTitle } from "../SectionTitle";
@@ -32,14 +32,22 @@ const renderer: CountdownRendererFn = ({ days, hours, minutes, seconds }) => (
 
 const HoldingPage = () => {
   const { claim } = useStore();
-  let date = new Date(0);
-  date.setUTCSeconds(parseInt(claim.claimOpensTs || "0"));
+  const [date, setDate] = useState(null);
+
+  // Super weird workaround so that NextJs doesn't report client/server render miss match
+  useEffect(() => {
+    setTimeout(() => {
+      let date = new Date(0);
+      date.setUTCSeconds(parseInt(claim.claimOpensTs || "0"));
+      setDate(date);
+    }, 1);
+  }, []);
 
   return (
     <>
       <PageTitle>OGV token launch countdown</PageTitle>
       <CardGroup>
-        <Countdown date={date} renderer={renderer} />
+        {date && <Countdown date={date} renderer={renderer} />}
         <Card>
           <SectionTitle>
             <div className="flex items-center justify-between">

--- a/client/components/layout.tsx
+++ b/client/components/layout.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, ReactNode } from "react";
 import Header from "components/Header";
 import Footer from "components/Footer";
+import AdminUtils from "components/AdminUtils";
 
 interface LayoutProps {
   children: ReactNode;
@@ -16,6 +17,7 @@ const Layout: FunctionComponent<LayoutProps> = ({ children, hideNav }) => (
         <div className="relative z-5">{children}</div>
       </div>
     </div>
+    <AdminUtils />
     <Footer />
   </div>
 );

--- a/client/pages/_middleware.ts
+++ b/client/pages/_middleware.ts
@@ -1,12 +1,12 @@
 import { NextResponse, NextRequest } from "next/server";
-import { claimIsOpen } from "utils";
+//import { claimIsOpen } from "utils";
 
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const homeRegEx = /^\/$/;
 
-  // If the claim hasn't started
-  if (homeRegEx.test(pathname) && claimIsOpen()) {
+  // until we unlock proposals just redirect all homepage traffic to claim
+  if (homeRegEx.test(pathname)) {
     // Redirect everything to /claim
     const claimUrl = req.nextUrl.clone();
     claimUrl.pathname = "/claim";

--- a/client/pages/claim.tsx
+++ b/client/pages/claim.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { NextPage } from "next";
 import Wrapper from "components/Wrapper";
 import StepTracker from "components/StepTracker";
@@ -17,14 +17,31 @@ const ClaimPage: NextPage<ClaimPageProps> = () => {
   const handleNextStep = () => setCurrentStep(currentStep + 1);
   const handlePrevStep = () => setCurrentStep(currentStep - 1);
 
+  const [claimOpenTsPassed, setClaimOpenTsPassed] = useState(
+    claimOpenTimestampPassed()
+  );
+  const [claimOpen, setClaimOpen] = useState(claimIsOpen());
+
+  useEffect(() => {
+    // check every second so component re-renders when counter reaches 0
+    const claimOpensTimer = setInterval(() => {
+      setClaimOpenTsPassed(claimOpenTimestampPassed());
+      setClaimOpen(claimIsOpen());
+    }, 1000);
+
+    return () => {
+      clearInterval(claimOpensTimer);
+    };
+  }, []);
+
   return (
     <div className="space-y-6">
-      {!claimOpenTimestampPassed() && (
+      {!claimOpenTsPassed && (
         <Wrapper narrow>
           <HoldingPage />
         </Wrapper>
       )}
-      {claimIsOpen() && (
+      {claimOpen && (
         <>
           <Wrapper narrow>
             <StepTracker currentStep={currentStep} steps={steps} />

--- a/client/utils/index.tsx
+++ b/client/utils/index.tsx
@@ -123,23 +123,23 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json());
 export { fetcher };
 
 export function claimOpensTimestamp() {
-  return parseInt(process.env.CLAIM_OPENS || "0");
+  return parseInt(useStore.getState().claim.claimOpensTs || "0");
 }
 
 export function claimClosesTimestamp() {
-  return parseInt(process.env.CLAIM_CLOSES || "0");
+  return parseInt(useStore.getState().claim.claimClosesTs || "0");
 }
 
-const now = Math.floor(new Date().getTime() / 1000);
+const now = () => Math.floor(new Date().getTime() / 1000);
 
 export function claimOpenTimestampPassed() {
   if (!claimOpensTimestamp()) return true;
-  return now > claimOpensTimestamp();
+  return now() > claimOpensTimestamp();
 }
 
 export function claimIsOpen() {
   if (!claimOpensTimestamp() || !claimClosesTimestamp()) return false;
-  return now > claimOpensTimestamp() && now < claimClosesTimestamp();
+  return now() > claimOpensTimestamp() && now() < claimClosesTimestamp();
 }
 
 export function sleep(ms) {

--- a/client/utils/store.tsx
+++ b/client/utils/store.tsx
@@ -37,6 +37,10 @@ const defaultState: Web3DataType = {
     existingEndWeeks: 0,
     existingEndDate: "",
   },
+  claim: {
+    claimOpensTs: process.env.CLAIM_OPENS,
+    claimClosesTs: process.env.CLAIM_CLOSES,
+  },
   lockups: {
     lockups: [],
     totalOgvLockedUp: ethers.BigNumber.from("0"),


### PR DESCRIPTION
- minor fixes so that claim page re-renders when timer reaches 0
- homepage redirects to claims by default (we should change that when we enable proposal creation)
- Adds Admin tools to be able to override claim open/closes timers (see screenshot below). Menu is enabled by running `localStorage.setItem("admin", "true");` from the browser console

<img width="987" alt="Screenshot 2022-07-08 at 14 02 54" src="https://user-images.githubusercontent.com/579910/177988841-7475930e-6e45-401a-92c0-5ebce88e113f.png">
 
**fixes:** https://github.com/OriginProtocol/ousd-governance/issues/171 https://github.com/OriginProtocol/ousd-governance/issues/184