### PR TITLE
Fix inconsistent OGV figures

### DIFF
--- a/client/components/Modal.tsx
+++ b/client/components/Modal.tsx
@@ -18,7 +18,7 @@ const Modal: FunctionComponent<ModalProps> = ({
 
   return (
     <div className={className} style={{ marginTop: 0 }} onClick={handleClose}>
-      <div className="modal-box bg-white">{children}</div>
+      <div className="modal-box overflow-hidden bg-white">{children}</div>
     </div>
   );
 };

--- a/client/components/TokenAmount.tsx
+++ b/client/components/TokenAmount.tsx
@@ -8,8 +8,13 @@ interface TokenAmount {
 
 const TokenAmount: FunctionComponent<TokenAmount> = ({ amount }) => {
   if (typeof amount == "string" || typeof amount == "number") {
+    if (typeof amount == "number" && Number.isInteger(amount))
+      return numeral(+amount)
+        .format("0 a")
+        .trim();
+
     return numeral(+amount)
-      .format("0 a")
+      .format("0.00 a")
       .trim();
   }
 

--- a/client/components/claim/claim/PostClaimModal.tsx
+++ b/client/components/claim/claim/PostClaimModal.tsx
@@ -86,8 +86,8 @@ const PostClaimModalProps: FunctionComponent<PostClaimModalProps> = ({
                     <span className="text-sm">
                       {didLock ? "You have locked" : "You have claimed"}
                     </span>
-                    <Card tightPadding noShadow alt>
-                      <div className="flex justify-center">
+                    <Card noPadding noShadow alt>
+                      <div className="flex justify-center p-2">
                         <div className="flex space-x-[0.4rem] items-end">
                           <TokenIcon large src="/ogv.svg" alt="OGV" />
                           <CardStat large>
@@ -101,8 +101,8 @@ const PostClaimModalProps: FunctionComponent<PostClaimModalProps> = ({
                   {didLock && (
                     <div className="space-y-2 flex flex-col">
                       <span className="text-sm">You have claimed</span>
-                      <Card tightPadding noShadow alt>
-                        <div className="flex justify-center">
+                      <Card noPadding noShadow alt>
+                        <div className="flex justify-center p-2">
                           <div className="flex space-x-[0.4rem] items-end">
                             <TokenIcon large src="/veogv.svg" alt="veOGV" />
                             <CardStat large>


### PR DESCRIPTION
Addresses: #167 

- If token amounts aren't whole (decimals not integers), display them to 2 decimal places, so as to display correct figures that sum up to the total claimable 
- Reduce padding in the UI to allow for more breathing room to show these additional decimal places (which have resulted in longer numbers to fit in smaller spaces)

![Screenshot 2022-07-08 at 14 06 46](https://user-images.githubusercontent.com/2827412/178000155-a9a78351-2582-41b2-965c-33262daf833c.png)

![Screenshot 2022-07-08 at 14 06 57](https://user-images.githubusercontent.com/2827412/178000176-aac8c6cc-2bd9-46c9-8dd2-f7d732488aee.png)

![Screenshot 2022-07-08 at 14 17 24](https://user-images.githubusercontent.com/2827412/178000228-1a9717f6-507a-4bbd-9c1f-9f1f8461df14.png)