### PR TITLE
Lockups DB fix

### DIFF
--- a/client/components/AdminUtils.js
+++ b/client/components/AdminUtils.js
@@ -15,7 +15,7 @@ const AdminUtils = () => {
     useStore.setState({
       claim: {
         ...useStore.getState().claim,
-        claimOpensTs
+        claimOpensTs,
       },
     });
   };
@@ -24,10 +24,10 @@ const AdminUtils = () => {
     useStore.setState({
       claim: {
         ...useStore.getState().claim,
-        currentStep: 2
-      }
+        currentStep: 2,
+      },
     });
-  }
+  };
 
   const buttonClass = "px-2 py-1 my-1 border border-black rounded-md";
   return (
@@ -57,10 +57,7 @@ const AdminUtils = () => {
         >
           Reset Open Claims
         </button>
-        <button
-          className={buttonClass}
-          onClick={skipEducation}
-        >
+        <button className={buttonClass} onClick={skipEducation}>
           Skip Education
         </button>
       </div>

--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -173,8 +173,7 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
     const valid = await validateForm();
 
     if (valid) {
-      // const now = (await web3Provider.getBlock()).timestamp;
-      const duration = lockupDuration * 2629746; // Months to seconds
+      const duration = lockupDuration * SECONDS_IN_A_MONTH; // Months to seconds
 
       const transaction = await contracts.OgvStaking["stake(uint256,uint256)"](
         ethers.utils.parseUnits(lockupAmount),

--- a/client/pages/claim.tsx
+++ b/client/pages/claim.tsx
@@ -19,10 +19,10 @@ const ClaimPage: NextPage<ClaimPageProps> = () => {
     useStore.setState({
       claim: {
         ...claim,
-        currentStep: currentStep + stepChange
-      }
+        currentStep: currentStep + stepChange,
+      },
     });
-  }
+  };
   const steps = ["Check Eligibility", "Learn about Origin", "Claim Airdrop"];
 
   const handleNextStep = () => updateCurrentStep(+1);
@@ -44,7 +44,7 @@ const ClaimPage: NextPage<ClaimPageProps> = () => {
       clearInterval(claimOpensTimer);
     };
   }, []);
-  
+
   return (
     <div className="space-y-6">
       {!claimOpenTsPassed && (

--- a/client/prisma/migrations/20220708174222_revise_lockup_structure/migration.sql
+++ b/client/prisma/migrations/20220708174222_revise_lockup_structure/migration.sql
@@ -1,0 +1,40 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `amount` on the `lockups` table. All the data in the column will be lost.
+  - You are about to drop the column `end` on the `lockups` table. All the data in the column will be lost.
+  - You are about to drop the column `points` on the `lockups` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[last_seen_block]` on the table `listener` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[lockupId]` on the table `lockups` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[proposal_id]` on the table `proposals` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[address]` on the table `voters` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "listener_last_seen_block_key";
+
+-- DropIndex
+DROP INDEX "lockups_lockupId_key";
+
+-- DropIndex
+DROP INDEX "proposals_proposal_id_key";
+
+-- DropIndex
+DROP INDEX "voters_address_key";
+
+-- AlterTable
+ALTER TABLE "lockups" DROP COLUMN "amount",
+DROP COLUMN "end",
+DROP COLUMN "points";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "listener_last_seen_block_key" ON "listener"("last_seen_block");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lockups_lockupId_key" ON "lockups"("lockupId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "proposals_proposal_id_key" ON "proposals"("proposal_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "voters_address_key" ON "voters"("address");

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -39,9 +39,6 @@ model Listener {
 model Lockup {
   lockupId  Int @unique
   user      String
-  amount    Decimal @db.Decimal(78, 0)
-  end       String
-  points    Decimal @db.Decimal(78, 0)
   createdAt DateTime @default(now()) @map("created_at")
 
   @@index([user], type: BTree)

--- a/client/utils/store.tsx
+++ b/client/utils/store.tsx
@@ -40,7 +40,7 @@ const defaultState: Web3DataType = {
   claim: {
     claimOpensTs: process.env.CLAIM_OPENS,
     claimClosesTs: process.env.CLAIM_CLOSES,
-    currentStep: 0
+    currentStep: 0,
   },
   lockups: {
     lockups: [],

--- a/client/utils/useLockups.tsx
+++ b/client/utils/useLockups.tsx
@@ -3,7 +3,6 @@ import { useStore } from "utils/store";
 import { useNetworkInfo, claimIsOpen } from "utils/index";
 import { fetcher } from "utils/index";
 import useSWR, { mutate } from "swr";
-import { ethers } from "ethers";
 
 const useLockups = () => {
   const [reloadLockups, setReloadLockups] = useState(0);


### PR DESCRIPTION
This addresses a bug that meant lockups weren't being added correctly to the database.

Because we enrich the lockup data by requesting from the contracts on-chain, we don't need to store anything other than `address` and `lockupId` at the time of the event.

This had been changed in some places, but not in the prisma schema.

- Schema updated
- Migration command ran
- Small timestamp fix added to vote escrow lockup creation (sidequest while I was here)