### PR TITLE
Contract timings uniformity

### DIFF
--- a/client/components/AdminUtils.js
+++ b/client/components/AdminUtils.js
@@ -15,7 +15,7 @@ const AdminUtils = () => {
     useStore.setState({
       claim: {
         ...useStore.getState().claim,
-        claimOpensTs
+        claimOpensTs,
       },
     });
   };
@@ -24,10 +24,10 @@ const AdminUtils = () => {
     useStore.setState({
       claim: {
         ...useStore.getState().claim,
-        currentStep: 2
-      }
+        currentStep: 2,
+      },
     });
-  }
+  };
 
   const buttonClass = "px-2 py-1 my-1 border border-black rounded-md";
   return (
@@ -57,10 +57,7 @@ const AdminUtils = () => {
         >
           Reset Open Claims
         </button>
-        <button
-          className={buttonClass}
-          onClick={skipEducation}
-        >
+        <button className={buttonClass} onClick={skipEducation}>
           Skip Education
         </button>
       </div>

--- a/client/pages/claim.tsx
+++ b/client/pages/claim.tsx
@@ -19,10 +19,10 @@ const ClaimPage: NextPage<ClaimPageProps> = () => {
     useStore.setState({
       claim: {
         ...claim,
-        currentStep: currentStep + stepChange
-      }
+        currentStep: currentStep + stepChange,
+      },
     });
-  }
+  };
   const steps = ["Check Eligibility", "Learn about Origin", "Claim Airdrop"];
 
   const handleNextStep = () => updateCurrentStep(+1);
@@ -44,7 +44,7 @@ const ClaimPage: NextPage<ClaimPageProps> = () => {
       clearInterval(claimOpensTimer);
     };
   }, []);
-  
+
   return (
     <div className="space-y-6">
       {!claimOpenTsPassed && (

--- a/client/utils/store.tsx
+++ b/client/utils/store.tsx
@@ -40,7 +40,7 @@ const defaultState: Web3DataType = {
   claim: {
     claimOpensTs: process.env.CLAIM_OPENS,
     claimClosesTs: process.env.CLAIM_CLOSES,
-    currentStep: 0
+    currentStep: 0,
   },
   lockups: {
     lockups: [],

--- a/contracts/MandatoryLockupDistributor.sol
+++ b/contracts/MandatoryLockupDistributor.sol
@@ -47,11 +47,11 @@ contract MandatoryLockupDistributor is AbstractLockupDistributor {
 
         IERC20(token).approve(stakingContract, _amount);
 
-        // Create four lockups for a year each
-        IOGVStaking(stakingContract).stake(_amount / 4, 52 weeks, msg.sender);
-        IOGVStaking(stakingContract).stake(_amount / 4, 104 weeks, msg.sender);
-        IOGVStaking(stakingContract).stake(_amount / 4, 156 weeks, msg.sender);
-        IOGVStaking(stakingContract).stake(_amount / 4, 208 weeks, msg.sender);
+        // Create four lockups in 12 month increments (1 month = 30 days)
+        IOGVStaking(stakingContract).stake(_amount / 4, 360 days, msg.sender); // 30 * 12
+        IOGVStaking(stakingContract).stake(_amount / 4, 720 days, msg.sender); // 30 * 24
+        IOGVStaking(stakingContract).stake(_amount / 4, 1080 days, msg.sender); // 30 * 36
+        IOGVStaking(stakingContract).stake(_amount / 4, 1440 days, msg.sender); // 30 * 48
 
         emit Claimed(_index, msg.sender, _amount);
     }

--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -215,7 +215,7 @@ contract OgvStaking is ERC20Votes {
         returns (uint256, uint256)
     {
         require(duration >= minStakeDuration, "Staking: Too short");
-        require(duration <= 1461 days, "Staking: Too long");
+        require(duration <= 1440 days, "Staking: Too long"); // 1 month = 30 days
         uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
         uint256 end = start + duration;
         uint256 endYearpoc = ((end - epoch) * 1e18) / 365 days;

--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -215,7 +215,7 @@ contract OgvStaking is ERC20Votes {
         returns (uint256, uint256)
     {
         require(duration >= minStakeDuration, "Staking: Too short");
-        require(duration <= 1440 days, "Staking: Too long"); // 1 month = 30 days
+        require(duration <= 1461 days, "Staking: Too long");
         uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
         uint256 end = start + duration;
         uint256 endYearpoc = ((end - epoch) * 1e18) / 365 days;

--- a/tests/distribution/test_mandatory_lockup.py
+++ b/tests/distribution/test_mandatory_lockup.py
@@ -1,6 +1,6 @@
 from brownie import *
 import brownie
-from ..helpers import WEEK
+from ..helpers import WEEK, DAY
 from ..fixtures import mandatory_lockup_distributor, token, rewards, staking
 
 merkle_proof = [
@@ -22,13 +22,13 @@ def test_claim(mandatory_lockup_distributor, token, staking):
     lockup_three = staking.lockups(accounts.default, 2)
     lockup_four = staking.lockups(accounts.default, 3)
     assert lockup_one[0] == amount / 4
-    assert lockup_one[1] == tx.timestamp + 52 * WEEK
+    assert lockup_one[1] == tx.timestamp + 360 * DAY
     assert lockup_two[0] == amount / 4
-    assert lockup_two[1] == tx.timestamp + 104 * WEEK
+    assert lockup_two[1] == tx.timestamp + 720 * DAY
     assert lockup_three[0] == amount / 4
-    assert lockup_three[1] == tx.timestamp + 156 * WEEK
+    assert lockup_three[1] == tx.timestamp + 1080 * DAY
     assert lockup_four[0] == amount / 4
-    assert lockup_four[1] == tx.timestamp + 208 * WEEK
+    assert lockup_four[1] == tx.timestamp + 1440 * DAY
 
 
 def test_can_not_claim(mandatory_lockup_distributor, token):


### PR DESCRIPTION
Since we've decided that 1 month = 30 days, we should make sure we have uniformity across the dApp and contracts.

I've updated the dApp earlier, and this brings the contracts in line. I've not created any Brownie tests (I'm not sure if it breaks our current ones), but have tested locally — this will definitely need eyes on to check.

Here's me locking up from both types of claim and from the vote escrow. As you can see the end dates now align, no matter where lockups are created from.

![Screenshot 2022-07-08 at 19 14 39](https://user-images.githubusercontent.com/2827412/178048425-a50a01f7-613d-4e4a-94b6-f3fbf18b3ec5.png)

Note: @sparrowDom is investigating a potential bug in the staking rewards calculations (if you notice these numbers being off in the screenshot). [ref #199]
