### PR TITLE
fix preview points calculation

### DIFF
--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -216,10 +216,8 @@ contract OgvStaking is ERC20Votes {
     {
         require(duration >= minStakeDuration, "Staking: Too short");
         require(duration <= 1461 days, "Staking: Too long");
-        //uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
-        uint256 start = block.timestamp;
+        uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
         uint256 end = start + duration;
-        //uint256 endYearpoc = ((end - epoch) * 1e18) / 365 days;
         uint256 endYearpoc = (duration * 1e18) / 365 days;
         uint256 multiplier = PRBMathUD60x18.pow(YEAR_BASE, endYearpoc);
         return ((amount * multiplier) / 1e18, end);

--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -216,9 +216,11 @@ contract OgvStaking is ERC20Votes {
     {
         require(duration >= minStakeDuration, "Staking: Too short");
         require(duration <= 1461 days, "Staking: Too long");
-        uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
+        //uint256 start = block.timestamp > epoch ? block.timestamp : epoch;
+        uint256 start = block.timestamp;
         uint256 end = start + duration;
-        uint256 endYearpoc = ((end - epoch) * 1e18) / 365 days;
+        //uint256 endYearpoc = ((end - epoch) * 1e18) / 365 days;
+        uint256 endYearpoc = (duration * 1e18) / 365 days;
         uint256 multiplier = PRBMathUD60x18.pow(YEAR_BASE, endYearpoc);
         return ((amount * multiplier) / 1e18, end);
     }


### PR DESCRIPTION
~~I am not 100% sure what the role of the `epoch` is in the contract. Whether it was suppose to be a rounding period to which all the timestamps "snap" to or something else. Will leave it to @DanielVF to sort it out, or maybe anyone else has an idea?~~

~~So I've made a change where the calculation of preview points is fixed and starts returning "normal" values. There is probably some intended logic in there that we still want to get in place before the launch.~~