### PR TITLE
Listener: allow start before claiming and fix small bug

### DIFF
--- a/client/listener.ts
+++ b/client/listener.ts
@@ -6,7 +6,6 @@ import { ethers } from "ethers";
 import EthereumEvents from "ethereum-events";
 import prisma, { Prisma } from "lib/prisma";
 import { CHAIN_CONTRACTS, RPC_URLS } from "constants/index";
-import { claimOpenTimestampPassed } from "utils/index";
 
 const logger = winston.createLogger({
   format: winston.format.simple(),
@@ -15,11 +14,6 @@ const logger = winston.createLogger({
 
 const networkId = process.env.NETWORK_ID;
 const GovernanceContracts = CHAIN_CONTRACTS[networkId];
-
-if(!claimOpenTimestampPassed()) {
-  logger.error("Claim not open yet");
-  process.exit(0);
-}
 
 if (!networkId) {
   logger.error("No network id specified");
@@ -182,7 +176,7 @@ prisma.listener.findFirst().then(async (listener) => {
       listenBlock = Math.abs(listener.lastSeenBlock - blockNumber) > 200 ? blockNumber : listener.lastSeenBlock;
     } else {
       // in production continue where left off last time
-      listener.lastSeenBlock
+      listenBlock = listener.lastSeenBlock
     }
   }
   ethereumEvents.start(listenBlock);


### PR DESCRIPTION
Maybe I'm missing some context but I can't think of a reason we would not want the listener to be starting off before the claiming period starts. Uncommented that check. It was causing the listener to not come up in production.

Also fixed a bug where when restarting in production, the listener would always start at block 0. Which would cause reprocessing all the events at every restart.