### PR TITLE
fix constraint bug

### DIFF
--- a/client/prisma/migrations/20220709224025_remove_lockup_id_constraint/migration.sql
+++ b/client/prisma/migrations/20220709224025_remove_lockup_id_constraint/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[last_seen_block]` on the table `listener` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[proposal_id]` on the table `proposals` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[address]` on the table `voters` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "listener_last_seen_block_key";
+
+-- DropIndex
+DROP INDEX "lockups_lockupId_key";
+
+-- DropIndex
+DROP INDEX "proposals_proposal_id_key";
+
+-- DropIndex
+DROP INDEX "voters_address_key";
+
+-- AlterTable
+ALTER TABLE "lockups" ADD COLUMN     "id" SERIAL NOT NULL,
+ADD CONSTRAINT "lockups_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "listener_last_seen_block_key" ON "listener"("last_seen_block");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "proposals_proposal_id_key" ON "proposals"("proposal_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "voters_address_key" ON "voters"("address");

--- a/client/prisma/migrations/20220709225440_add_compound_unique_constraint/migration.sql
+++ b/client/prisma/migrations/20220709225440_add_compound_unique_constraint/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[last_seen_block]` on the table `listener` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[lockupId,user]` on the table `lockups` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[proposal_id]` on the table `proposals` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[address]` on the table `voters` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "listener_last_seen_block_key";
+
+-- DropIndex
+DROP INDEX "proposals_proposal_id_key";
+
+-- DropIndex
+DROP INDEX "voters_address_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "listener_last_seen_block_key" ON "listener"("last_seen_block");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "lockups_lockupId_user_key" ON "lockups"("lockupId", "user");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "proposals_proposal_id_key" ON "proposals"("proposal_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "voters_address_key" ON "voters"("address");

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Lockup {
   user      String
   createdAt DateTime @default(now()) @map("created_at")
 
+  @@unique([lockupId, user])
   @@index([user], type: BTree)
   @@map("lockups")
 }

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -37,7 +37,8 @@ model Listener {
 }
 
 model Lockup {
-  lockupId  Int @unique
+  id        Int @default(autoincrement()) @id
+  lockupId  Int
   user      String
   createdAt DateTime @default(now()) @map("created_at")
 


### PR DESCRIPTION
Removes lockupId constraint and add unique auto increment id -> requirement of Prisma. Tested locally, entry created in db and UI: 
<img width="643" alt="Screenshot 2022-07-10 at 00 44 22" src="https://user-images.githubusercontent.com/579910/178124951-7bb8bb89-a70e-4118-9fed-69fcecf657ad.png">
<img width="592" alt="Screenshot 2022-07-10 at 00 44 45" src="https://user-images.githubusercontent.com/579910/178124952-50402de0-ab55-4da7-ad1f-bbef2ef891ee.png">

