### PR TITLE
Lockup UI polish

### DIFF
--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -315,7 +315,9 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
             disabled={
               !lockupAmount ||
               !lockupDuration ||
-              allowances.ogv.gte(ethers.utils.parseUnits(lockupAmount))
+              allowances.ogv.gte(ethers.utils.parseUnits(lockupAmount)) ||
+              lockupStatus === "waiting-for-user" ||
+              lockupStatus === "waiting-for-network"
             }
             onClick={handleApproval}
           >


### PR DESCRIPTION
Addresses: #135 

- Button text changes depending on transaction status
- Buttons are disabled when transactions are waiting for approval/being mined
- Better error handling (message on failure) for both approval and lockup transactions
- Note: Decided against the modal as we already have the toasts providing additional status
- Note: Some clean up of previously commented out code