### PR TITLE
Show locked OGV not veOGV in eligibility table

### DIFF
--- a/client/components/claim/EligibilityItem.tsx
+++ b/client/components/claim/EligibilityItem.tsx
@@ -39,12 +39,12 @@ const EligibilityItem: FunctionComponent<EligibilityItemProps> = ({
           <div className="flex space-x-2 items-center">
             <TokenIcon
               src="/ogv.svg"
-              alt={showOgvToken ? "OGV" : "locked OGV"}
+              alt={showOgvToken ? "OGV" : "pre-locked OGV"}
             />
             <ReactTooltip id={id} place="top" type="dark" effect="solid">
               <span>
                 <span className="mr-1">{utils.formatUnits(tokens, 18)}</span>
-                {showOgvToken ? "OGV" : "locked OGV"}
+                {showOgvToken ? "OGV" : "pre-locked OGV"}
               </span>
             </ReactTooltip>
             <div data-tip data-for={id}>
@@ -52,7 +52,7 @@ const EligibilityItem: FunctionComponent<EligibilityItemProps> = ({
                 <span className="mr-1">
                   {formatCurrency(utils.formatUnits(tokens, 18))}
                 </span>
-                {showOgvToken ? "OGV" : "locked OGV"}
+                {showOgvToken ? "OGV" : "pre-locked OGV"}
               </span>
             </div>
           </div>

--- a/client/components/claim/EligibilityItem.tsx
+++ b/client/components/claim/EligibilityItem.tsx
@@ -38,13 +38,13 @@ const EligibilityItem: FunctionComponent<EligibilityItemProps> = ({
         <td className="p-0 sm:p-4">
           <div className="flex space-x-2 items-center">
             <TokenIcon
-              src={showOgvToken ? "/ogv.svg" : "/veogv.svg"}
-              alt={showOgvToken ? "OGV" : "veOGV"}
+              src="/ogv.svg"
+              alt={showOgvToken ? "OGV" : "locked OGV"}
             />
             <ReactTooltip id={id} place="top" type="dark" effect="solid">
               <span>
                 <span className="mr-1">{utils.formatUnits(tokens, 18)}</span>
-                {showOgvToken ? "OGV" : "veOGV"}
+                {showOgvToken ? "OGV" : "locked OGV"}
               </span>
             </ReactTooltip>
             <div data-tip data-for={id}>
@@ -52,7 +52,7 @@ const EligibilityItem: FunctionComponent<EligibilityItemProps> = ({
                 <span className="mr-1">
                   {formatCurrency(utils.formatUnits(tokens, 18))}
                 </span>
-                {showOgvToken ? "OGV" : "veOGV"}
+                {showOgvToken ? "OGV" : "locked OGV"}
               </span>
             </div>
           </div>


### PR DESCRIPTION
I just noticed this while testing:

It doesn't make sense to show veOGV as the token received in the eligibility phase for OUSD holders, because the amount and token type don't align.

For instance: If someone qualifies for the airdrop from being an OUSD (or wOUSD) holder, they receive the amount of OGV specified, but pre-locked. They don't receive the amount of OGV 1 for 1 as veOGV. It's actually higher than we show.

This could also cause confusion at the final claim stage where we show locked OGV eligible for then the veOGV to be received today.

Proposed changes to the token table, from:

![Screenshot 2022-07-10 at 11 54 13](https://user-images.githubusercontent.com/2827412/178141956-2f3453b6-06ce-4631-a413-dc2ecff6bd8d.png)

To:

![Screenshot 2022-07-10 at 11 57 40](https://user-images.githubusercontent.com/2827412/178142024-e9e18e91-7a57-4c01-9b63-0bbe81eec5f2.png)

