### PR TITLE
Update seconds in a month in mandatory merkle distributor

### DIFF
--- a/contracts/MandatoryLockupDistributor.sol
+++ b/contracts/MandatoryLockupDistributor.sol
@@ -47,11 +47,11 @@ contract MandatoryLockupDistributor is AbstractLockupDistributor {
 
         IERC20(token).approve(stakingContract, _amount);
 
-        // Create four lockups in 12 month increments (1 month = 30 days)
-        IOGVStaking(stakingContract).stake(_amount / 4, 360 days, msg.sender); // 30 * 12
-        IOGVStaking(stakingContract).stake(_amount / 4, 720 days, msg.sender); // 30 * 24
-        IOGVStaking(stakingContract).stake(_amount / 4, 1080 days, msg.sender); // 30 * 36
-        IOGVStaking(stakingContract).stake(_amount / 4, 1440 days, msg.sender); // 30 * 48
+        // Create four lockups in 12 month increments (1 month = 2629800 seconds)
+        IOGVStaking(stakingContract).stake(_amount / 4, 2629800 * 12, msg.sender);
+        IOGVStaking(stakingContract).stake(_amount / 4, 2629800 * 24, msg.sender);
+        IOGVStaking(stakingContract).stake(_amount / 4, 2629800 * 36, msg.sender);
+        IOGVStaking(stakingContract).stake(_amount / 4, 2629800 * 48, msg.sender);
 
         emit Claimed(_index, msg.sender, _amount);
     }

--- a/tests/distribution/test_mandatory_lockup.py
+++ b/tests/distribution/test_mandatory_lockup.py
@@ -22,13 +22,13 @@ def test_claim(mandatory_lockup_distributor, token, staking):
     lockup_three = staking.lockups(accounts.default, 2)
     lockup_four = staking.lockups(accounts.default, 3)
     assert lockup_one[0] == amount / 4
-    assert lockup_one[1] == tx.timestamp + 360 * DAY
+    assert lockup_one[1] == tx.timestamp + 12 * 2629800
     assert lockup_two[0] == amount / 4
-    assert lockup_two[1] == tx.timestamp + 720 * DAY
+    assert lockup_two[1] == tx.timestamp + 24 * 2629800
     assert lockup_three[0] == amount / 4
-    assert lockup_three[1] == tx.timestamp + 1080 * DAY
+    assert lockup_three[1] == tx.timestamp + 36 * 2629800
     assert lockup_four[0] == amount / 4
-    assert lockup_four[1] == tx.timestamp + 1440 * DAY
+    assert lockup_four[1] == tx.timestamp + 48 * 2629800
 
 
 def test_can_not_claim(mandatory_lockup_distributor, token):


### PR DESCRIPTION
This updates the mandatory lockup durations based on the new seconds in a month figure (`2629800`), in line with the dApp.

Requires review.