### PR TITLE
Fix rounding on lockup form

### DIFF
--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -10,7 +10,6 @@ import RangeInput from "components/RangeInput";
 import useLockups from "utils/useLockups";
 import useTotalBalances from "utils/useTotalBalances";
 import LockupTable from "components/vote-escrow/LockupTable";
-import moment from "moment";
 import { SECONDS_IN_A_MONTH } from "../../constants/index";
 
 interface LockupFormProps {
@@ -244,9 +243,16 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
       setLockupStatus("waiting-for-user");
 
       let transaction;
+
+      // If lockup amount === 100% of the user's OGV balance then use the actual balance BigNumber
+      let amountToStake = ethers.utils.parseUnits(lockupAmount);
+      if (lockupAmount === formattedOgvBalance) {
+        amountToStake = balances.ogv; // Prevents rounding
+      }
+
       try {
         transaction = await contracts.OgvStaking["stake(uint256,uint256)"](
-          ethers.utils.parseUnits(lockupAmount),
+          amountToStake,
           duration,
           // 228123 * 1.5
           { gasLimit: 342184 }

--- a/scripts/31337_data/optional_lockup_accounts.json
+++ b/scripts/31337_data/optional_lockup_accounts.json
@@ -2,12 +2,12 @@
     "0x8dea6Ef7767e0D6ae7Dd9D144E514D7DFAe75B36": {
         "amount": {
             "type": "BigNumber",
-            "hex": "0x0410d586a20a4c0000"
+            "hex": "0x417C5E1FBDDFE0000"
         },
         "split": {
             "ogn": {
                 "type": "BigNumber",
-                "hex": "0x4563918244f40000"
+                "hex": "0x4C53ECDC18A60000"
             },
             "ognStaking": {
                 "type": "BigNumber",

--- a/scripts/31337_data/optional_lockup_claims.json
+++ b/scripts/31337_data/optional_lockup_claims.json
@@ -1,16 +1,16 @@
 {
-  "merkleRoot": "0xec6b85a27b356b663919338d00c0594df746445a5a0d317ba670e450a7771447",
+  "merkleRoot": "0x4285464fa8590f26b43260f1136b637818947bdd5ba963e98357ad197b0c807b",
   "claims": {
     "0x8dea6Ef7767e0D6ae7Dd9D144E514D7DFAe75B36": {
       "index": 0,
       "amount": {
         "type": "BigNumber",
-        "hex": "0x0410d586a20a4c0000"
+        "hex": "0x417C5E1FBDDFE0000"
       },
       "split": {
         "ogn": {
           "type": "BigNumber",
-          "hex": "0x4563918244f40000"
+          "hex": "0x4C53ECDC18A60000"
         },
         "ognStaking": {
           "type": "BigNumber",
@@ -62,7 +62,7 @@
         }
       },
       "proof": [
-        "0x7e87926430fe964a0ed53ca1e79b742e495865dadeb897aa44a253c7de5213d8"
+        "0xf2eb44f1386ed20fe32f388305fe329f8497505cfbd838bc6efd68036fa01fa5"
       ]
     }
   }


### PR DESCRIPTION
A quick fix to address #260:

- We identified that non-round number 100% stakes would revert due to rounding
- This is because the input slider requires a string version (or "formatted" version) of the actual BigNumber balance so the UX plays nicely
- This results in, non-round, 100% stakes, being passed as slightly higher to the contract, causing a revert due to the user trying to stake more OGV than they have
- **The fix** in this PR detects whether a user wants to stake 100% of their OGV holdings and bypasses the slider input value in favour of their actual balance of OGV (which is untouched, and thus not rounded)
- We only do this when 100% is selected because we can safely assume that the user has enough OGV to cover the slight rounding on any lower percentages 

Screenshots of the fix in flow:

1. User has a non-round amount of OGV to claim
![Screenshot 2022-07-15 at 08 17 35](https://user-images.githubusercontent.com/2827412/179173586-57a2205e-ecfb-4c7f-b01e-c4a53bb3f971.png)

2. User claims without staking
![Screenshot 2022-07-15 at 08 17 52](https://user-images.githubusercontent.com/2827412/179173649-10eda2b5-f39a-4469-adf4-cedaf68e9038.png)
 
3. User stakes 100% of their balance successfully
![Screenshot 2022-07-15 at 08 19 04](https://user-images.githubusercontent.com/2827412/179173754-83edc6b2-88d1-4f4c-9189-7abbade570b5.png)
![Screenshot 2022-07-15 at 08 19 14](https://user-images.githubusercontent.com/2827412/179173767-a4cc76c2-1254-4c3f-9191-dbefc4754412.png)
![Screenshot 2022-07-15 at 08 19 23](https://user-images.githubusercontent.com/2827412/179173792-6ccfc8dc-5d5d-4e2f-8178-0cc5f1a0892e.png)
![Screenshot 2022-07-15 at 08 19 43](https://user-images.githubusercontent.com/2827412/179173807-053db15a-97ca-443e-b547-a744a9eeb0b0.png)
