### PR TITLE
Fix for skipped gas optimization

### DIFF
--- a/contracts/RewardsSource.sol
+++ b/contracts/RewardsSource.sol
@@ -39,7 +39,7 @@ contract RewardsSource is Governable {
     /// @return rewards OGV collected
     function collectRewards() external returns (uint256) {
         require(msg.sender == rewardsTarget, "Rewards: Not rewardsTarget");
-        require(lastRewardTime > 0, "Rewards: lastRewardTime is zero"); // Ensures initialziation
+        require(lastRewardTime > 0, "Rewards: lastRewardTime is zero"); // Ensures initialization
         if (block.timestamp <= lastRewardTime) {
             return 0;
         }
@@ -86,7 +86,7 @@ contract RewardsSource is Governable {
             uint256 rangeStart = last;
             uint256 rangeEnd = block.timestamp;
             if (rangeEnd < slopeStart) {
-                break; // No future slope could match
+                break; // No current or future slope could match
             }
             if (rangeStart < slopeStart) {
                 rangeStart = slopeStart; // trim to slope edge
@@ -99,7 +99,7 @@ contract RewardsSource is Governable {
             if (i > _currentSlopeIndex && duration > 0) {
                 nextSlopeIndex = i; // We have moved into a new slope
             }
-            if (slopeEnd < rangeEnd) {
+            if (rangeEnd < slopeEnd) {
                 break; // No future slope could match
             }
         }


### PR DESCRIPTION
There was comparison backwards in RewardsSource.sol, which skipped a gas optimization. This did not change the behavior of the contract, but did result in an extra trip through the loop and an extra storage load.

## Background:

_calcRewards determine how the amount of OGV that is created as inflation. To do this, it checks the range of time that has passed to the current time since the last inflation, and then creates the needed inflation for that time range. 

The function loops through configurable inflation slope time segments, determine how much of the range is in each, and thus the inflation earned in that slope.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/837/179792762-949b8c72-079a-4445-9243-fae10ddedf33.png">

To speed things up there are two gas optimizations made: 

1. We start our loop at the last used inflation slope, allowing us to skip all the inflation slopes before.
2. If the end of the range fits inside the current slope, we know that no further sloop could overlap, and skip further checks.

Most of the time the range we are working with fits entirely inside the current slope. Because of the two optimizations  the only slope configuration that we need to read from storage is the current slope.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/837/179793709-b4e58bcd-4b66-4cf6-b8fc-71d8b2c371cc.png">

## Bug

The comparison check for the second optimization was backwards, checking that the local range end was into the next slope, which would never happen because the local range is trimmed to the slope end, and thus the optimization could never fire.

## Fix

Fixing the bug improves gas usage.

<img width="584" alt="image" src="https://user-images.githubusercontent.com/837/179794570-c7ea2a9a-fda7-4dfb-a1fb-2a3b6ae37aca.png">

Even more importantly, there's not a logic bug sneaking around in the contract, waiting to explode some future change.

Given the small change in gas usage, we won't deploy this fix separately, but it will be a part of any future upgrade.

# Thanks!

Thanks to [okkothejawa](https://twitter.com/okkothejawa) for spotting this!