### PR TITLE
Add space between error message and staking details

### DIFF
--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -522,8 +522,10 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
           </CardGroup>
         </div>
         {transactionError && (
-          <div className="p-6 bg-[#dd0a0a1a] border border-[#dd0a0a] rounded-lg text-2xl text-center font-bold text-[#dd0a0a]">
-            {transactionError}
+          <div className="pt-4">
+            <div className="p-6 bg-[#dd0a0a1a] border border-[#dd0a0a] rounded-lg text-2xl text-center font-bold text-[#dd0a0a]">
+              {transactionError}
+            </div>
           </div>
         )}
         <div className="flex pt-6">


### PR DESCRIPTION
Addresses: #278 

![Screenshot 2022-07-27 at 10 51 43](https://user-images.githubusercontent.com/2827412/181218463-68238e93-82f7-429f-8402-262d2efdd58a.png)

