### PR TITLE
Pick out % amounts

### DIFF
--- a/client/components/vote-escrow/YourLockups.tsx
+++ b/client/components/vote-escrow/YourLockups.tsx
@@ -141,9 +141,20 @@ const YourLockups: FunctionComponent<YourLockupsProps> = () => {
     <Card>
       <div className="mb-20">
         <div className="space-y-4 bg-accent text-white -my-10 -mx-6 p-10 md:-mx-10">
-          <h2 className="text-2xl font-bold">
-            {totalPercentageOfLockedUpOgv.toFixed(2)}% of all OGV is currently
-            staked. OGV stakers earn {stakingApy.toFixed(2)}% variable APY.
+          <h2 className="text-2xl space-y-1">
+            <span className="block border-b pb-3 border-secondary/[.15]">
+              <span className="font-bold bg-secondary px-[4px] py-[1px] rounded">
+                {totalPercentageOfLockedUpOgv.toFixed(2)}%
+              </span>{" "}
+              of all OGV is currently staked
+            </span>
+            <span className="block pt-2">
+              OGV stakers earn{" "}
+              <span className="font-bold bg-secondary px-[4px] py-[1px] rounded">
+                {stakingApy.toFixed(2)}%
+              </span>{" "}
+              variable APY
+            </span>
           </h2>
         </div>
       </div>


### PR DESCRIPTION
Addresses: #277

![Screenshot 2022-07-27 at 11 05 28](https://user-images.githubusercontent.com/2827412/181221596-96521aac-0124-4403-b728-9fdfd1d34c56.png)

@micahalcorn This seems to work well in our style. The darker green we use for positive enforcement of APY percentages elsewhere so it makes sense to stick to the same pattern. Setting the text on two lines helps with the mobile layout and further emphasizes the two numbers in their own right. LMK what you think.
