### PR TITLE
Remove check that prevents slider going below current duration

### DIFF
--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -430,26 +430,10 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
           max={maxLockupDurationInMonths}
           value={lockupDuration}
           onChange={(e) => {
-            if (
-              existingLockup &&
-              e.target.value <=
-                Math.floor(
-                  (existingLockup?.end - blockTimestamp) / SECONDS_IN_A_MONTH
-                )
-            )
-              return;
             setLockupDuration(e.target.value);
           }}
           markers={lockupDurationInputMarkers}
           onMarkerClick={(markerValue) => {
-            if (
-              existingLockup &&
-              markerValue <=
-                Math.floor(
-                  (existingLockup?.end - blockTimestamp) / SECONDS_IN_A_MONTH
-                )
-            )
-              return;
             if (markerValue) {
               setLockupDuration(markerValue);
             }


### PR DESCRIPTION
Addresses: #271 

- Removes the slider check that prevents stake extensions from being set lower than their existing amount
- Check still exists on submit transaction button
- This also fixes the bug demonstrated in the video from #271 

![Screenshot 2022-08-01 at 11 38 35](https://user-images.githubusercontent.com/2827412/182132367-b7765ac9-0f95-429f-9ea8-00618bd0210a.png)
![Screenshot 2022-08-01 at 11 38 29](https://user-images.githubusercontent.com/2827412/182132375-ea5bba23-84fc-499b-b930-12672c170c43.png)

