### PR TITLE
Override default timestamp on entry creation

### DIFF
--- a/client/listener.ts
+++ b/client/listener.ts
@@ -111,6 +111,7 @@ const handleStake = async (event) => {
             create: [{
               hash: event.transactionHash,
               event: "Extend",
+              createdAt: new Date(event.timestamp * 1000),
             }],
           },
           active: true,
@@ -134,6 +135,7 @@ const handleStake = async (event) => {
             create: [{
               hash: event.transactionHash,
               event: event.name,
+              createdAt: new Date(event.timestamp * 1000),
             }],
           },
           active: true,


### PR DESCRIPTION
- Prevents transactions showing as created at the time of entry
- Adds timestamps from block of event