### PR TITLE
Prevents errors on missing event in the ABI

### DIFF
--- a/client/listener.ts
+++ b/client/listener.ts
@@ -54,6 +54,7 @@ const options = {
   chunkSize: 1000, // n° of blocks to fetch at a time (default: 10000)
   concurrency: 10, // maximum n° of concurrent web3 requests (default: 10)
   backoff: 1000, // retry backoff in milliseconds (default: 1000)
+  ignoreUnknownEvents: true,
 };
 
 const web3 = new Web3(WEB3_PROVIDER);

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
     "dotenv": "^16.0.0",
     "eslint": "8.9.0",
     "eslint-config-next": "12.1.0",
-    "ethereum-events": "^0.1.3",
+    "ethereum-events": "https://github.com/AleG94/ethereum-events#develop",
     "ethers": "^5.5.4",
     "keccak256": "^1.0.6",
     "lodash": "^4.17.21",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3599,10 +3599,9 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
-ethereum-events@^0.1.3:
+"ethereum-events@https://github.com/AleG94/ethereum-events#develop":
   version "0.1.3"
-  resolved "https://registry.npmjs.org/ethereum-events/-/ethereum-events-0.1.3.tgz"
-  integrity sha512-5Y2R54ubc6sQpjrVA0v43DBFIhS3UZlo6guCF+OPxVb1ybYbqP/XGy97vChs7cYL+l+F3X5D2jDiH+hi58AbTQ==
+  resolved "https://github.com/AleG94/ethereum-events#8c92ade1d8f489a577399d5d3cd0093ef6c58aa5"
   dependencies:
     eth-log-parser "^0.1.0"
     p-limit "^3.0.1"


### PR DESCRIPTION
This fixes #316 and should be merged before we attempt to release `master` to `stable` again.

Note: The feature flag required is on the `develop` branch of the dependency's repo.