### PR TITLE
add a local copy of ERC20BurnableUpgradeable that doesn't have the ex…

### DIFF
--- a/contracts/GovernanceToken.sol
+++ b/contracts/GovernanceToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import "./upgrades/ERC20BurnableUpgradeable.sol";
 import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/access/OwnableUpgradeable.sol";
 import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/access/AccessControlUpgradeable.sol";
 import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/proxy/utils/Initializable.sol";

--- a/contracts/upgrades/ERC20BurnableUpgradeable.sol
+++ b/contracts/upgrades/ERC20BurnableUpgradeable.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC20/extensions/ERC20Burnable.sol)
+
+pragma solidity ^0.8.0;
+
+import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/utils/ContextUpgradeable.sol";
+import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/proxy/utils/Initializable.sol";
+import "OpenZeppelin/openzeppelin-contracts-upgradeable@4.6.0/contracts/token/ERC20/ERC20Upgradeable.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20BurnableUpgradeable is Initializable, ContextUpgradeable, ERC20Upgradeable {
+    function __ERC20Burnable_init() internal onlyInitializing {
+    }
+
+    function __ERC20Burnable_init_unchained() internal onlyInitializing {
+    }
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(_msgSender(), amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        _spendAllowance(account, _msgSender(), amount);
+        _burn(account, amount);
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     * 
+     * (!) Important we are commenting this out so it doesn't mess up the storage layout
+     * of our already deployed OriginDollarGovernance(GovernanceToken.sol) contract. 
+     */
+    //uint256[50] private __gap;
+}


### PR DESCRIPTION
Create a local repo copy of ERC20BurnableUpgradeable contract and remove the `_gap` so that storage slots remain intact. [See this PR](https://github.com/OriginProtocol/origin-dollar/pull/1128) to verify the various storage slot layouts. 

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
