### PR TITLE
remove the check for claims being open

### DIFF
--- a/client/utils/useAccountBalances.js
+++ b/client/utils/useAccountBalances.js
@@ -36,12 +36,7 @@ const useAccountBalances = () => {
       return await contracts.OgvStaking.previewRewards(address);
     };
 
-    if (
-      web3Provider &&
-      address &&
-      networkInfo.correct &&
-      contracts.loaded
-    ) {
+    if (web3Provider && address && networkInfo.correct && contracts.loaded) {
       Promise.all([
         loadOgvBalance(),
         loadVeOgvBalance(),
@@ -72,12 +67,7 @@ const useAccountBalances = () => {
       );
     };
 
-    if (
-      web3Provider &&
-      address &&
-      networkInfo.correct &&
-      contracts.loaded
-    ) {
+    if (web3Provider && address && networkInfo.correct && contracts.loaded) {
       Promise.all([loadAllowance()]).then(([ogv_approval]) => {
         useStore.setState({
           allowances: {

--- a/client/utils/useAccountBalances.js
+++ b/client/utils/useAccountBalances.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useStore } from "utils/store";
-import { useNetworkInfo, claimIsOpen } from "utils/index";
+import { useNetworkInfo } from "utils/index";
 
 const useAccountBalances = () => {
   const [reloadAccountAllowances, setReloadAccountAllowances] = useState(0);
@@ -37,7 +37,6 @@ const useAccountBalances = () => {
     };
 
     if (
-      claimIsOpen() &&
       web3Provider &&
       address &&
       networkInfo.correct &&
@@ -74,7 +73,6 @@ const useAccountBalances = () => {
     };
 
     if (
-      claimIsOpen() &&
       web3Provider &&
       address &&
       networkInfo.correct &&

--- a/client/utils/useContracts.tsx
+++ b/client/utils/useContracts.tsx
@@ -4,7 +4,7 @@ import { ethers } from "ethers";
 import OUSDContracts from "networks/network.mainnet.json";
 import { mainnetNetworkUrl, RPC_URLS, CHAIN_CONTRACTS } from "constants/index";
 import { useStore } from "utils/store";
-import { claimIsOpen, useNetworkInfo } from "utils/index";
+import { useNetworkInfo } from "utils/index";
 
 const useContracts = () => {
   const { web3Provider, chainId } = useStore();
@@ -71,9 +71,7 @@ const useContracts = () => {
         contracts,
       });
     };
-    if (claimIsOpen()) {
-      loadContracts();
-    }
+    loadContracts();
   }, [web3Provider, chainId, networkInfo.envNetwork]);
 };
 

--- a/client/utils/useLockups.tsx
+++ b/client/utils/useLockups.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useStore } from "utils/store";
-import { useNetworkInfo, claimIsOpen } from "utils/index";
+import { useNetworkInfo } from "utils/index";
 import { fetcher } from "utils/index";
 import useSWR, { mutate } from "swr";
 import { sortBy } from "lodash";
@@ -44,7 +44,6 @@ const useLockups = () => {
     };
 
     if (
-      claimIsOpen() &&
       web3Provider &&
       networkInfo.correct &&
       address &&

--- a/client/utils/useTotalBalances.tsx
+++ b/client/utils/useTotalBalances.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useStore } from "utils/store";
-import { claimIsOpen } from "utils/index";
 import numeral from "numeraljs";
 import { decimal18Bn } from "utils";
 
@@ -31,7 +30,7 @@ const useTotalBalances = () => {
         contracts.MandatoryDistributor.address
       );
 
-    if (claimIsOpen() && contracts.loaded) {
+    if (contracts.loaded) {
       Promise.all([
         loadTotalSupplyOfOgv(),
         loadTotalLockedUpOgv(),


### PR DESCRIPTION
On a couple of places we had a check that didn't start interacting with contracts until the staking Claims were not open. This PR removes that check