### PR TITLE
Increase extend gas allowance

### DIFF
--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -347,7 +347,7 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
         transaction = await contracts.OgvStaking["extend(uint256,uint256)"](
           existingLockup.lockupId,
           duration,
-          { gasLimit: 195000 }
+          { gasLimit: 220000 }
         );
       } catch (e) {
         setTransactionError("Error extending lockup!");


### PR DESCRIPTION
This moves gas sent for `extend` transactions up from a hardcoded 195,000 up to 220,000.

This should fix the failing transactions on extends.