### PR TITLE
Revise gas limits

### DIFF
--- a/client/components/vote-escrow/LockupForm.tsx
+++ b/client/components/vote-escrow/LockupForm.tsx
@@ -347,7 +347,7 @@ const LockupForm: FunctionComponent<LockupFormProps> = ({ existingLockup }) => {
         transaction = await contracts.OgvStaking["extend(uint256,uint256)"](
           existingLockup.lockupId,
           duration,
-          { gasLimit: 220000 }
+          { gasLimit: 240000 }
         );
       } catch (e) {
         setTransactionError("Error extending lockup!");

--- a/client/components/vote-escrow/LockupsTable.tsx
+++ b/client/components/vote-escrow/LockupsTable.tsx
@@ -38,8 +38,8 @@ const LockupsTable: FunctionComponent = () => {
   const handleUnlock = async (lockupId) => {
     const transaction = await contracts.OgvStaking["unstake(uint256)"](
       lockupId,
-      { gasLimit: 1000000 }
-    ); // @TODO maybe set this to lower
+      { gasLimit: 210000 }
+    );
 
     useStore.setState({
       pendingTransactions: [

--- a/client/components/vote-escrow/YourLockups.tsx
+++ b/client/components/vote-escrow/YourLockups.tsx
@@ -63,8 +63,8 @@ const YourLockups: FunctionComponent<YourLockupsProps> = () => {
     let transaction;
     try {
       transaction = await contracts.OgvStaking["collectRewards()"]({
-        gasLimit: 1000000,
-      }); // @TODO maybe set this to lower
+        gasLimit: 1400000,
+      });
     } catch (e) {
       setCollectRewardsStatus("ready");
       throw e;

--- a/client/components/vote-escrow/YourLockups.tsx
+++ b/client/components/vote-escrow/YourLockups.tsx
@@ -63,7 +63,7 @@ const YourLockups: FunctionComponent<YourLockupsProps> = () => {
     let transaction;
     try {
       transaction = await contracts.OgvStaking["collectRewards()"]({
-        gasLimit: 1400000,
+        gasLimit: 140000,
       });
     } catch (e) {
       setCollectRewardsStatus("ready");


### PR DESCRIPTION
We currently have UX problems with our gas limits on everything but staking. Extend often has too low of a gas limit, which causes failed transactions. Collect and unstake have very high limits, which cause users to complain about the perceived expense of exiting their positions. We should consider eventually switching to dynamic gas limits using an estimate + buffer, but this should be a step forward.

‣ [Quick assessment of historical gas usage](https://docs.google.com/spreadsheets/d/1VzDYs5mC8911AG5MyGdyNlu0BqZmvgK0zdesRyF3nxY/edit)