### PR TITLE
N-01 Simplify calculation in previewWithdraw

### DIFF
--- a/contracts/ExponentialStaking.sol
+++ b/contracts/ExponentialStaking.sol
@@ -265,8 +265,8 @@ contract ExponentialStaking is ERC20Votes {
         }
         uint256 fullDuration = end - block.timestamp;
         (uint256 fullPoints,) = previewPoints(1e18, fullDuration);
-        (uint256 currentPoints,) = previewPoints(1e36, 0); // 1e36 saves a later multiplication
-        return amount * ((currentPoints / fullPoints)) / 1e18;
+        (uint256 currentPoints,) = previewPoints(1e18, 0);
+        return amount * currentPoints / fullPoints;
     }
 
     /// @notice Returns the total number of lockups the user has


### PR DESCRIPTION
### From OZ

_Consider changing the double parentheses to single parentheses in line 269 of the
ExponentialStaking contract._

### Change

We can simplify the calculation of withdraw amounts, and with it get a much smaller rounding error, less gas usage, and simpler code.


The previous code did the following:

```solidity
    (uint256 fullPoints,) = previewPoints(1e18, fullDuration);
    (uint256 currentPoints,) = previewPoints(1e36, 0); // 1e36 saves a later multiplication
    return amount * (currentPoints / fullPoints) / 1e18;
```

When that last line is expanded it out, and executed in order of operation it is roughly: mul(constant), div, mul, div(constant). This ordering means that any rounding errors in `currentPoints / fullPoints` are magnified by the size of `amount`.

Changing this to:

```solidity
    (uint256 fullPoints,) = previewPoints(1e18, fullDuration);
    (uint256 currentPoints,) = previewPoints(1e18, 0);
    return amount * currentPoints / fullPoints;
```

And the calculation is now a single mul / div. The removes the multiplication of error, keeping the error size constant regardless of the amount. It's also one fewer operation.

### Effects

The change in the results  between these two methods is minimal because `previewPoints`, as used in this function, will always return a number 1e18 in size or greater. This caps the error in the initial multiplication and division to 1/1e18, which in turn capped the final error to something approximately 1e18th of the amount size. Had previewPoints been returning much smaller numbers, then the rounding error multiplication could have been impactful.

### Verification

To do comparative testing on this, add the following fuzzing test to `ExponentialStakingTest` and the old method to `ExponentialStaking`.

```solidity
function testFuzzPreviousPreviewWithdraw(uint128 amount, uint64 duration, uint32 startOffset) public {
        uint256 start = EPOCH + startOffset;
        uint256 end = start + duration % (305 days);
        vm.warp(start);
        uint256 oldMethod = staking.previewWithdrawOld(amount, end);
        uint256 newMethod = staking.previewWithdraw(amount, end);
        assertLe(newMethod * 1e18, (oldMethod + 1) * (1e18 + 2), "le");
        assertGe(newMethod, oldMethod, "ge");
}
```

```solidity
function previewWithdrawOld(uint256 amount, uint256 end) public view returns (uint256) {
    if (block.timestamp >= end) {
        return amount;
    }
    uint256 fullDuration = end - block.timestamp;
    (uint256 fullPoints,) = previewPoints(1e18, fullDuration);
    (uint256 currentPoints,) = previewPoints(1e36, 0); // 1e36 saves a later multiplication
    return amount * (currentPoints / fullPoints) / 1e18;
}
```

Run with

`FOUNDRY_FUZZ_RUNS=500000 forge test -vvvv --mt testFuzzPreviousPreviewWithdraw`