### PR TITLE
One day delay before governance voting

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -17,7 +17,11 @@ contract Governance is
 {
     constructor(ERC20Votes _token, TimelockController _timelock)
         Governor("Origin DeFi Governance")
-        GovernorSettings(1, /* 1 block */ 14416, /* ~2 days (86400 / 12) * 2 */ 100000 * 1e18 /* 100k xOGN */ )
+        GovernorSettings(
+            7200, /* ~1 day (86400 / 12) */
+            14416, /* ~2 days (86400 / 12) * 2 */
+            100000 * 1e18 /* 100k xOGN */
+        )
         GovernorVotes(_token)
         GovernorVotesQuorumFraction(20) // Default quorum denominator is 100, so 20/100 or 20%
         GovernorTimelockControl(_timelock)

--- a/tests/governance/XOGNGovernanceForkTest.t.sol
+++ b/tests/governance/XOGNGovernanceForkTest.t.sol
@@ -48,7 +48,7 @@ contract XOGNGovernanceForkTest is Test {
 
         ognRewardsSource = deployManager.getDeployment("OGN_REWARDS_SOURCE");
 
-        vm.startPrank(Addresses.OGN_GOVERNOR);
+        vm.startPrank(Addresses.TIMELOCK);
         ogn.mint(alice, 200000 ether);
         ogn.mint(bob, 200000 ether);
         ogn.mint(xognWhale, 1000_000_000 ether);
@@ -68,7 +68,7 @@ contract XOGNGovernanceForkTest is Test {
     }
 
     function testVotingDelay() external view {
-        assertEq(xognGov.votingDelay(), 1, "Incorrect voting delay");
+        assertEq(xognGov.votingDelay(), 7200, "Incorrect voting delay");
     }
 
     function testVotingPeriod() external view {
@@ -201,8 +201,8 @@ contract XOGNGovernanceForkTest is Test {
         assertEq(uint256(xognGov.state(proposalId)), 0, "Proposal wasn't created");
 
         // Wait for voting to start
-        vm.warp(block.timestamp + 10 minutes);
-        vm.roll(block.number + 100);
+        vm.warp(block.timestamp + 1 days);
+        vm.roll(block.number + 7300);
         assertEq(uint256(xognGov.state(proposalId)), 1, "Proposal isn't active");
 
         // Vote on proposal
@@ -258,8 +258,8 @@ contract XOGNGovernanceForkTest is Test {
         assertEq(uint256(xognGov.state(proposalId)), 0, "Proposal wasn't created");
 
         // Wait for voting to start
-        vm.warp(block.timestamp + 10 minutes);
-        vm.roll(block.number + 100);
+        vm.warp(block.timestamp + 1 days);
+        vm.roll(block.number + 7300);
         assertEq(uint256(xognGov.state(proposalId)), 1, "Proposal isn't active");
 
         // Vote on proposal


### PR DESCRIPTION
We wish to add a one day delay before voting starts to allow for people to rebalance their xOGN if they want before an important vote.

----

If you made a contract change, make sure to complete the checklist below before merging it in master.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
