### PR TITLE
Add MigrationZapper

### DIFF
--- a/build/deployments.json
+++ b/build/deployments.json
@@ -2,9 +2,11 @@
   "1": {
     "executions": {
       "010_xOGNSetup": 1716312107,
-      "011_OgnOgvMigration": 1716485925
+      "011_OgnOgvMigration": 1716485925,
+      "012_MigrationZapper": 1716910212
     },
     "contracts": {
+      "MIGRATION_ZAPPER": "0xC202CDa20A8C34C7a282890eAE2Bb9CC0B115877",
       "MIGRATOR": "0x95c347D6214614A780847b8aAF4f96Eb84f4da6d",
       "MIGRATOR_IMPL": "0x946e9BED9EDebEBCE95Dea72bDD38F8c3F6efd2E",
       "OGN_REWARDS_SOURCE": "0x7609c88E5880e934dd3A75bCFef44E31b1Badb8b",

--- a/contracts/MigrationZapper.sol
+++ b/contracts/MigrationZapper.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+import {IStaking} from "./interfaces/IStaking.sol";
+import {IMigrator} from "./interfaces/IMigrator.sol";
+import {IMintableERC20} from "./interfaces/IMintableERC20.sol";
+
+contract MigrationZapper {
+    IMintableERC20 public immutable ogv;
+    IMintableERC20 public immutable ogn;
+
+    IMigrator public immutable migrator;
+    IStaking public immutable ognStaking;
+
+    constructor(address _ogv, address _ogn, address _migrator, address _ognStaking) {
+        ogv = IMintableERC20(_ogv);
+        ogn = IMintableERC20(_ogn);
+        migrator = IMigrator(_migrator);
+        ognStaking = IStaking(_ognStaking);
+    }
+
+    function initialize() external {
+        // Migrator can move OGV and OGN from this contract
+        ogv.approve(address(migrator), type(uint256).max);
+        ogn.approve(address(ognStaking), type(uint256).max);
+    }
+
+    /**
+     * @notice Migrates the specified amount of OGV to OGN.
+     * @param ogvAmount Amount of OGV to migrate
+     */
+    function migrate(uint256 ogvAmount) external {
+        // Take tokens in
+        ogv.transferFrom(msg.sender, address(this), ogvAmount);
+
+        // Proxy migrate call
+        uint256 ognReceived = migrator.migrate(ogvAmount);
+
+        // Transfer OGN to the receiver
+        ogn.transfer(msg.sender, ognReceived);
+    }
+
+    /**
+     * @notice Migrates the specified amount of OGV to OGN
+     *         and stakes it.
+     * @param ogvAmount Amount of OGV to migrate
+     */
+    function migrate(uint256 ogvAmount, uint256 newStakeAmount, uint256 newStakeDuration) external {
+        // Take tokens in
+        ogv.transferFrom(msg.sender, address(this), ogvAmount);
+
+        // Migrate
+        uint256 ognReceived = migrator.migrate(ogvAmount);
+
+        // Stake on behalf of user
+        ognStaking.stake(
+            newStakeAmount,
+            newStakeDuration,
+            msg.sender,
+            false,
+            -1 // New stake
+        );
+    }
+}

--- a/contracts/Migrator.sol
+++ b/contracts/Migrator.sol
@@ -4,15 +4,7 @@ pragma solidity 0.8.10;
 import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "./Governable.sol";
 
-interface IStaking {
-    function delegates(address staker) external view returns (address);
-
-    // From OGVStaking.sol
-    function unstakeFrom(address staker, uint256[] memory lockupIds) external returns (uint256, uint256);
-
-    // From ExponentialStaking.sol
-    function stake(uint256 amountIn, uint256 duration, address to, bool stakeRewards, int256 lockupId) external;
-}
+import {IStaking} from "./interfaces/IStaking.sol";
 
 contract Migrator is Governable {
     ERC20Burnable public immutable ogv;

--- a/contracts/interfaces/IMigrator.sol
+++ b/contracts/interfaces/IMigrator.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+interface IMigrator {
+    function migrate(uint256 ogvAmount) external returns (uint256);
+
+    function migrate(
+        uint256[] calldata lockupIds,
+        uint256 ogvAmountFromWallet,
+        uint256 ognAmountFromWallet,
+        bool migrateRewards,
+        uint256 newStakeAmount,
+        uint256 newStakeDuration
+    ) external;
+}

--- a/contracts/interfaces/IMintableERC20.sol
+++ b/contracts/interfaces/IMintableERC20.sol
@@ -6,5 +6,6 @@ interface IMintableERC20 {
     function balanceOf(address owner) external view returns (uint256);
     function totalSupply() external view returns (uint256);
     function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address _from, address to, uint256 amount) external returns (bool);
     function approve(address spender, uint256 allowance) external;
 }

--- a/contracts/interfaces/IStaking.sol
+++ b/contracts/interfaces/IStaking.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.10;
+
+interface IStaking {
+    function delegates(address staker) external view returns (address);
+
+    // From OGVStaking.sol
+    function unstakeFrom(address staker, uint256[] memory lockupIds) external returns (uint256, uint256);
+
+    // From ExponentialStaking.sol
+    function stake(uint256 amountIn, uint256 duration, address to, bool stakeRewards, int256 lockupId) external;
+}

--- a/script/deploy/DeployManager.sol
+++ b/script/deploy/DeployManager.sol
@@ -8,7 +8,8 @@ import {BaseMainnetScript} from "./mainnet/BaseMainnetScript.sol";
 
 import {XOGNSetupScript} from "./mainnet/010_xOGNSetupScript.sol";
 import {OgnOgvMigrationScript} from "./mainnet/011_OgnOgvMigrationScript.sol";
-import {XOGNGovernanceScript} from "./mainnet/012_xOGNGovernanceScript.sol";
+import {MigrationZapperScript} from "./mainnet/012_MigrationZapperScript.sol";
+import {XOGNGovernanceScript} from "./mainnet/013_xOGNGovernanceScript.sol";
 
 import "contracts/utils/VmHelper.sol";
 
@@ -62,6 +63,7 @@ contract DeployManager is Script {
         // TODO: Use vm.readDir to recursively build this?
         _runDeployFile(new XOGNSetupScript());
         _runDeployFile(new OgnOgvMigrationScript());
+        _runDeployFile(new MigrationZapperScript());
         _runDeployFile(new XOGNGovernanceScript());
     }
 

--- a/script/deploy/mainnet/012_MigrationZapperScript.sol
+++ b/script/deploy/mainnet/012_MigrationZapperScript.sol
@@ -33,8 +33,9 @@ contract MigrationZapperScript is BaseMainnetScript {
         console.log("Deploy:");
         console.log("------------");
 
-        MigrationZapper zapper =
-            new MigrationZapper(Addresses.OGV, Addresses.OGN, deployedContracts["MIGRATOR"], deployedContracts["XOGN"]);
+        MigrationZapper zapper = new MigrationZapper(
+            Addresses.OGV, Addresses.OGN, deployedContracts["MIGRATOR"], deployedContracts["XOGN"], Addresses.TIMELOCK
+        );
         _recordDeploy("MIGRATION_ZAPPER", address(zapper));
 
         // Make sure Migrator can move OGV and OGN

--- a/script/deploy/mainnet/012_MigrationZapperScript.sol
+++ b/script/deploy/mainnet/012_MigrationZapperScript.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "./BaseMainnetScript.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {Addresses} from "contracts/utils/Addresses.sol";
+
+import {Timelock} from "contracts/Timelock.sol";
+import {Governance} from "contracts/Governance.sol";
+
+import {GovFive} from "contracts/utils/GovFive.sol";
+
+import {VmHelper} from "utils/VmHelper.sol";
+
+import {MigrationZapper} from "contracts/MigrationZapper.sol";
+
+import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/governance/TimelockController.sol";
+
+contract MigrationZapperScript is BaseMainnetScript {
+    using GovFive for GovFive.GovFiveProposal;
+    using VmHelper for Vm;
+
+    GovFive.GovFiveProposal public govProposal;
+
+    string public constant override DEPLOY_NAME = "012_MigrationZapper";
+
+    constructor() {}
+
+    function _execute() internal override {
+        console.log("Deploy:");
+        console.log("------------");
+
+        MigrationZapper zapper =
+            new MigrationZapper(Addresses.OGV, Addresses.OGN, deployedContracts["MIGRATOR"], deployedContracts["XOGN"]);
+        _recordDeploy("MIGRATION_ZAPPER", address(zapper));
+
+        // Make sure Migrator can move OGV and OGN
+        zapper.initialize();
+    }
+
+    function _buildGovernanceProposal() internal override {}
+
+    function _fork() internal override {}
+}

--- a/script/deploy/mainnet/013_xOGNGovernanceScript.sol
+++ b/script/deploy/mainnet/013_xOGNGovernanceScript.sol
@@ -23,7 +23,7 @@ contract XOGNGovernanceScript is BaseMainnetScript {
 
     GovFive.GovFiveProposal public govProposal;
 
-    string public constant override DEPLOY_NAME = "012_xOGNGovernance";
+    string public constant override DEPLOY_NAME = "013_xOGNGovernance";
 
     uint256 public constant OGN_EPOCH = 1717041600; // May 30, 2024 GMT
 

--- a/tests/staking/ZapperForkTest.t.sol
+++ b/tests/staking/ZapperForkTest.t.sol
@@ -76,7 +76,7 @@ contract ZapperForkTest is Test {
         uint256[] memory lockupIds = new uint256[](0);
         uint256 stakeAmount = (100 ether * 0.09137 ether) / 1 ether;
 
-        zapper.migrate(100 ether, 1 ether, 300 days);
+        zapper.migrate(100 ether, stakeAmount, 300 days);
 
         // Should have it in a single OGN lockup
         (uint128 amount, uint128 end, uint256 points) = xogn.lockups(ogvWhale, 0);

--- a/tests/staking/ZapperForkTest.t.sol
+++ b/tests/staking/ZapperForkTest.t.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "forge-std/Test.sol";
+
+import {Addresses} from "contracts/utils/Addresses.sol";
+import {DeployManager} from "script/deploy/DeployManager.sol";
+
+import {Migrator} from "contracts/Migrator.sol";
+import {MigrationZapper} from "contracts/MigrationZapper.sol";
+import {OgvStaking} from "contracts/OgvStaking.sol";
+import {ExponentialStaking} from "contracts/ExponentialStaking.sol";
+
+import {IMintableERC20} from "contracts/interfaces/IMintableERC20.sol";
+
+contract ZapperForkTest is Test {
+    DeployManager public deployManager;
+
+    Migrator public migrator;
+    MigrationZapper public zapper;
+    OgvStaking public veogv;
+    ExponentialStaking public xogn;
+    IMintableERC20 public ogv;
+    IMintableERC20 public ogn;
+
+    address public ogvWhale = Addresses.GOV_MULTISIG;
+
+    constructor() {
+        deployManager = new DeployManager();
+
+        deployManager.setUp();
+        deployManager.run();
+    }
+
+    function setUp() external {
+        migrator = Migrator(deployManager.getDeployment("MIGRATOR"));
+        zapper = MigrationZapper(deployManager.getDeployment("MIGRATION_ZAPPER"));
+
+        veogv = OgvStaking(Addresses.VEOGV);
+        ogv = IMintableERC20(Addresses.OGV);
+        ogn = IMintableERC20(Addresses.OGN);
+        xogn = ExponentialStaking(deployManager.getDeployment("XOGN"));
+
+        vm.startPrank(ogvWhale);
+        ogv.approve(address(migrator), type(uint256).max);
+        ogv.approve(address(zapper), type(uint256).max);
+        ogn.approve(address(migrator), type(uint256).max);
+        ogv.approve(address(veogv), type(uint256).max);
+        vm.stopPrank();
+    }
+
+    function testBalanceMigration() external {
+        vm.startPrank(ogvWhale);
+
+        uint256 migratorOGNReserve = ogn.balanceOf(address(migrator));
+        uint256 ogvSupply = ogv.totalSupply();
+        uint256 ogvBalanceBefore = ogv.balanceOf(ogvWhale);
+        uint256 ognBalanceBefore = ogn.balanceOf(ogvWhale);
+
+        // Should be able to swap OGV to OGN at fixed rate
+        zapper.migrate(100 ether);
+
+        assertEq(ogv.balanceOf(ogvWhale), ogvBalanceBefore - 100 ether, "More OGV burnt");
+        assertEq(ogv.totalSupply(), ogvSupply - 100 ether, "OGV supply mismatch");
+
+        assertEq(ogn.balanceOf(ogvWhale), ognBalanceBefore + 9.137 ether, "Less OGN received");
+        assertEq(ogn.balanceOf(address(migrator)), migratorOGNReserve - 9.137 ether, "More OGN sent");
+
+        vm.stopPrank();
+    }
+
+    function testMigrateBalanceAndStake() public {
+        vm.startPrank(ogvWhale);
+
+        uint256[] memory lockupIds = new uint256[](0);
+        uint256 stakeAmount = (100 ether * 0.09137 ether) / 1 ether;
+
+        zapper.migrate(100 ether, 1 ether, 300 days);
+
+        // Should have it in a single OGN lockup
+        (uint128 amount, uint128 end, uint256 points) = xogn.lockups(ogvWhale, 0);
+        assertEq(amount, stakeAmount, "Balance not staked");
+
+        vm.stopPrank();
+    }
+}


### PR DESCRIPTION
Right now, it's impossible to convert OGV to OGN and stake it in a single call if you don't have any OGV lockups with our Migrator contract.

The new `MigrationZapper` will allow users to do that. It internally calls `Migrator.migrate` and then stakes it on xOGN contract.

The simple `migrate(uint256)` should:
- Transfer in OGV from user's wallet
- Migrate it to OGN
- And transfer OGN back to the user

The other `migrate(uint256,uint256,uint256)` should:
- Transfer in OGV from user's wallet
- Migrate it to OGN
- Stake it on behalf of the user for specified duration
- Transfer back any leftover OGN to user
---------
If you made a contract change, make sure to complete the checklist below before merging it in master.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
