### PR TITLE
Migrator changes

### DIFF
--- a/contracts/Migrator.sol
+++ b/contracts/Migrator.sol
@@ -25,7 +25,6 @@ contract Migrator is Governable {
 
     error MigrationAlreadyStarted();
     error ContractInsolvent(uint256 expectedOGN, uint256 availableOGN);
-    error LockupIdsRequired();
     error InvalidStakeAmount();
 
     constructor(address _ogv, address _ogn, address _ogvStaking, address _ognStaking) {
@@ -131,12 +130,12 @@ contract Migrator is Governable {
             // Unstake if there are any lockups
             (uint256 ogvAmountUnlocked, uint256 rewardsCollected) = ogvStaking.unstakeFrom(msg.sender, lockupIds);
 
+            ogvAmountFromWallet += ogvAmountUnlocked;
+
             if (migrateRewards) {
                 // Include rewards if needed
                 ogvAmountFromWallet += rewardsCollected;
             }
-
-            ogvAmountFromWallet += ogvAmountUnlocked;
         } else if (migrateRewards) {
             uint256 rewardsCollected = ogvStaking.collectRewardsFrom(msg.sender);
             ogvAmountFromWallet += rewardsCollected;

--- a/contracts/OgvStaking.sol
+++ b/contracts/OgvStaking.sol
@@ -204,6 +204,12 @@ contract OgvStaking is ERC20Votes {
         _burn(staker, unstakedPoints);
     }
 
+    /// @notice Collects rewards from an user
+    /// @param staker Address of the user
+    function collectRewardsFrom(address staker) external onlyMigrator returns (uint256 rewardCollected) {
+        rewardCollected = _collectRewards(staker);
+    }
+
     /// @notice Extend a stake lockup for additional points.
     ///
     /// The stake end time is computed from the current time + duration, just

--- a/contracts/interfaces/IStaking.sol
+++ b/contracts/interfaces/IStaking.sol
@@ -7,6 +7,9 @@ interface IStaking {
     // From OGVStaking.sol
     function unstakeFrom(address staker, uint256[] memory lockupIds) external returns (uint256, uint256);
 
+    // From OGVStaking.sol
+    function collectRewardsFrom(address staker) external returns (uint256);
+
     // From ExponentialStaking.sol
     function stake(uint256 amountIn, uint256 duration, address to, bool stakeRewards, int256 lockupId) external;
 }

--- a/script/deploy/DeployManager.sol
+++ b/script/deploy/DeployManager.sol
@@ -9,7 +9,8 @@ import {BaseMainnetScript} from "./mainnet/BaseMainnetScript.sol";
 import {XOGNSetupScript} from "./mainnet/010_xOGNSetupScript.sol";
 import {OgnOgvMigrationScript} from "./mainnet/011_OgnOgvMigrationScript.sol";
 import {MigrationZapperScript} from "./mainnet/012_MigrationZapperScript.sol";
-import {XOGNGovernanceScript} from "./mainnet/013_xOGNGovernanceScript.sol";
+import {UpgradeMigratorScript} from "./mainnet/013_UpgradeMigratorScript.sol";
+import {XOGNGovernanceScript} from "./mainnet/014_xOGNGovernanceScript.sol";
 
 import "contracts/utils/VmHelper.sol";
 
@@ -64,6 +65,7 @@ contract DeployManager is Script {
         _runDeployFile(new XOGNSetupScript());
         _runDeployFile(new OgnOgvMigrationScript());
         _runDeployFile(new MigrationZapperScript());
+        _runDeployFile(new UpgradeMigratorScript());
         _runDeployFile(new XOGNGovernanceScript());
     }
 

--- a/script/deploy/mainnet/011_OgnOgvMigrationScript.sol
+++ b/script/deploy/mainnet/011_OgnOgvMigrationScript.sol
@@ -61,8 +61,6 @@ contract OgnOgvMigrationScript is BaseMainnetScript {
 
         console.log("- Migrator init");
         migratorProxy.initialize(address(migratorImpl), Addresses.TIMELOCK, "");
-
-        // _buildGovernanceProposal();
     }
 
     function _buildGovernanceProposal() internal override {

--- a/script/deploy/mainnet/013_UpgradeMigratorScript.sol
+++ b/script/deploy/mainnet/013_UpgradeMigratorScript.sol
@@ -15,6 +15,7 @@ import {GovFive} from "contracts/utils/GovFive.sol";
 import {VmHelper} from "utils/VmHelper.sol";
 
 import {Migrator} from "contracts/Migrator.sol";
+import {OgvStaking} from "contracts/OgvStaking.sol";
 
 import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/token/ERC20/extensions/ERC20Votes.sol";
 import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/governance/TimelockController.sol";
@@ -33,7 +34,15 @@ contract UpgradeMigratorScript is BaseMainnetScript {
         console.log("Deploy:");
         console.log("------------");
 
-        // Deploy implementation
+        // Deploy veOGV implementation
+        uint256 ogvMinStaking = 30 * 24 * 60 * 60; // 2592000 -> 30 days
+        uint256 ogvEpoch = OgvStaking(Addresses.VEOGV).epoch(); // Use old value.
+        OgvStaking veOgvImpl = new OgvStaking(
+            Addresses.OGV, ogvEpoch, ogvMinStaking, Addresses.OGV_REWARDS_PROXY, deployedContracts["MIGRATOR"]
+        );
+        _recordDeploy("VEOGV_IMPL", address(veOgvImpl));
+
+        // Deploy migrator implementation
         Migrator migratorImpl = new Migrator(Addresses.OGV, Addresses.OGN, Addresses.VEOGV, deployedContracts["XOGN"]);
         _recordDeploy("MIGRATOR_IMPL", address(migratorImpl));
     }
@@ -41,6 +50,10 @@ contract UpgradeMigratorScript is BaseMainnetScript {
     function _buildGovernanceProposal() internal override {
         govProposal.action(
             deployedContracts["MIGRATOR"], "upgradeTo(address)", abi.encode(deployedContracts["MIGRATOR_IMPL"])
+        );
+
+        govProposal.action(
+            deployedContracts["VEOGV"], "upgradeTo(address)", abi.encode(deployedContracts["VEOGV_IMPL"])
         );
     }
 

--- a/script/deploy/mainnet/013_UpgradeMigratorScript.sol
+++ b/script/deploy/mainnet/013_UpgradeMigratorScript.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "./BaseMainnetScript.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+import {Addresses} from "contracts/utils/Addresses.sol";
+
+import {Timelock} from "contracts/Timelock.sol";
+import {Governance} from "contracts/Governance.sol";
+
+import {GovFive} from "contracts/utils/GovFive.sol";
+
+import {VmHelper} from "utils/VmHelper.sol";
+
+import {Migrator} from "contracts/Migrator.sol";
+
+import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/token/ERC20/extensions/ERC20Votes.sol";
+import "OpenZeppelin/openzeppelin-contracts@4.6.0/contracts/governance/TimelockController.sol";
+
+contract UpgradeMigratorScript is BaseMainnetScript {
+    using GovFive for GovFive.GovFiveProposal;
+    using VmHelper for Vm;
+
+    GovFive.GovFiveProposal public govProposal;
+
+    string public constant override DEPLOY_NAME = "013_UpgradeMigrator";
+
+    constructor() {}
+
+    function _execute() internal override {
+        console.log("Deploy:");
+        console.log("------------");
+
+        // Deploy implementation
+        Migrator migratorImpl = new Migrator(Addresses.OGV, Addresses.OGN, Addresses.VEOGV, deployedContracts["XOGN"]);
+        _recordDeploy("MIGRATOR_IMPL", address(migratorImpl));
+    }
+
+    function _buildGovernanceProposal() internal override {
+        govProposal.action(
+            deployedContracts["MIGRATOR"], "upgradeTo(address)", abi.encode(deployedContracts["MIGRATOR_IMPL"])
+        );
+    }
+
+    function _fork() internal override {
+        // Simulate proposal
+        govProposal.printTxData();
+        govProposal.executeWithTimelock();
+    }
+}

--- a/script/deploy/mainnet/014_xOGNGovernanceScript.sol
+++ b/script/deploy/mainnet/014_xOGNGovernanceScript.sol
@@ -23,7 +23,7 @@ contract XOGNGovernanceScript is BaseMainnetScript {
 
     GovFive.GovFiveProposal public govProposal;
 
-    string public constant override DEPLOY_NAME = "013_xOGNGovernance";
+    string public constant override DEPLOY_NAME = "014_xOGNGovernance";
 
     uint256 public constant OGN_EPOCH = 1717041600; // May 30, 2024 GMT
 
@@ -38,8 +38,6 @@ contract XOGNGovernanceScript is BaseMainnetScript {
         Governance governance = new Governance(ERC20Votes(xOgnProxy), TimelockController(payable(Addresses.TIMELOCK)));
 
         _recordDeploy("XOGN_GOV", address(governance));
-
-        _buildGovernanceProposal();
     }
 
     function _buildGovernanceProposal() internal override {

--- a/tests/governance/XOGNGovernanceForkTest.t.sol
+++ b/tests/governance/XOGNGovernanceForkTest.t.sol
@@ -61,6 +61,8 @@ contract XOGNGovernanceForkTest is Test {
         vm.startPrank(bob);
         ogn.approve(address(xogn), 1e70);
         vm.stopPrank();
+
+        vm.warp(OGN_EPOCH + 100 days);
     }
 
     function testGovernanceName() external view {

--- a/tests/staking/MigratorForkTest.t.sol
+++ b/tests/staking/MigratorForkTest.t.sol
@@ -90,18 +90,18 @@ contract MigratorForkTest is Test {
         uint256 ogvBalanceBefore = ogv.balanceOf(ogvWhale);
         uint256 ognBalanceBefore = ogn.balanceOf(ogvWhale);
 
-        (uint128 amount, uint128 end, uint256 points) = veogv.lockups(ogvWhale, 13);
+        (uint128 amount, uint128 end, uint256 points) = veogv.lockups(ogvWhale, 1);
         uint256 ognTransferred = (amount * 9137e8) / 1e13;
 
         uint256[] memory lockupIds = new uint256[](1);
-        lockupIds[0] = 2;
+        lockupIds[0] = 1;
         migrator.migrate(lockupIds, 0, 0, false, 0, 0);
         assertEq(ogv.totalSupply(), ogvSupply - amount, "OGV supply mismatch");
         assertEq(ogn.balanceOf(address(migrator)), migratorOGNReserve - ognTransferred, "OGN reserve balance mismatch");
         assertEq(ogv.balanceOf(ogvWhale), ogvBalanceBefore, "Change in OGV balance");
         assertEq(ogn.balanceOf(ogvWhale), ognBalanceBefore + ognTransferred, "No change in OGN balance");
 
-        (amount, end, points) = veogv.lockups(ogvWhale, 2);
+        (amount, end, points) = veogv.lockups(ogvWhale, 1);
         assertEq(amount, 0, "Amount: Lockup still exists");
         assertEq(end, 0, "End: Lockup still exists");
         assertEq(points, 0, "Points: Lockup still exists");
@@ -113,9 +113,9 @@ contract MigratorForkTest is Test {
         vm.startPrank(ogvWhale);
 
         uint256[] memory lockupIds = new uint256[](1);
-        lockupIds[0] = 2;
+        lockupIds[0] = 1;
 
-        (uint128 amount, uint128 end, uint256 points) = veogv.lockups(ogvWhale, 13);
+        (uint128 amount, uint128 end, uint256 points) = veogv.lockups(ogvWhale, 1);
 
         uint256 stakeAmount = (amount * 9137e8) / 1e13;
 
@@ -125,13 +125,13 @@ contract MigratorForkTest is Test {
         (amount, end, points) = xogn.lockups(ogvWhale, 0);
         assertEq(amount, stakeAmount, "Lockup not migrated");
 
-        (amount, end, points) = veogv.lockups(ogvWhale, 2);
+        (amount, end, points) = veogv.lockups(ogvWhale, 1);
         assertEq(amount, 0, "Amount: Lockup still exists");
         assertEq(end, 0, "End: Lockup still exists");
         assertEq(points, 0, "Points: Lockup still exists");
 
         // Shouldn't have deleted other migration
-        (amount, end, points) = veogv.lockups(ogvWhale, 3);
+        (amount, end, points) = veogv.lockups(ogvWhale, 2);
         assertEq(amount > 0, true, "Other lockup deleted");
 
         vm.stopPrank();

--- a/tests/staking/MigratorForkTest.t.sol
+++ b/tests/staking/MigratorForkTest.t.sol
@@ -94,14 +94,14 @@ contract MigratorForkTest is Test {
         uint256 ognTransferred = (amount * 9137e8) / 1e13;
 
         uint256[] memory lockupIds = new uint256[](1);
-        lockupIds[0] = 13;
+        lockupIds[0] = 2;
         migrator.migrate(lockupIds, 0, 0, false, 0, 0);
         assertEq(ogv.totalSupply(), ogvSupply - amount, "OGV supply mismatch");
         assertEq(ogn.balanceOf(address(migrator)), migratorOGNReserve - ognTransferred, "OGN reserve balance mismatch");
         assertEq(ogv.balanceOf(ogvWhale), ogvBalanceBefore, "Change in OGV balance");
         assertEq(ogn.balanceOf(ogvWhale), ognBalanceBefore + ognTransferred, "No change in OGN balance");
 
-        (amount, end, points) = veogv.lockups(ogvWhale, 13);
+        (amount, end, points) = veogv.lockups(ogvWhale, 2);
         assertEq(amount, 0, "Amount: Lockup still exists");
         assertEq(end, 0, "End: Lockup still exists");
         assertEq(points, 0, "Points: Lockup still exists");
@@ -113,7 +113,7 @@ contract MigratorForkTest is Test {
         vm.startPrank(ogvWhale);
 
         uint256[] memory lockupIds = new uint256[](1);
-        lockupIds[0] = 13;
+        lockupIds[0] = 2;
 
         (uint128 amount, uint128 end, uint256 points) = veogv.lockups(ogvWhale, 13);
 
@@ -125,13 +125,13 @@ contract MigratorForkTest is Test {
         (amount, end, points) = xogn.lockups(ogvWhale, 0);
         assertEq(amount, stakeAmount, "Lockup not migrated");
 
-        (amount, end, points) = veogv.lockups(ogvWhale, 13);
+        (amount, end, points) = veogv.lockups(ogvWhale, 2);
         assertEq(amount, 0, "Amount: Lockup still exists");
         assertEq(end, 0, "End: Lockup still exists");
         assertEq(points, 0, "Points: Lockup still exists");
 
         // Shouldn't have deleted other migration
-        (amount, end, points) = veogv.lockups(ogvWhale, 14);
+        (amount, end, points) = veogv.lockups(ogvWhale, 3);
         assertEq(amount > 0, true, "Other lockup deleted");
 
         vm.stopPrank();
@@ -161,8 +161,8 @@ contract MigratorForkTest is Test {
 
         // Check migrating stakes as well
         uint256[] memory lockupIds = new uint256[](2);
-        lockupIds[0] = 13;
-        lockupIds[1] = 14;
+        lockupIds[0] = 2;
+        lockupIds[1] = 3;
         migrator.migrate(lockupIds, 0, 0, false, 0, 0);
 
         vm.stopPrank();

--- a/tests/staking/MigratorForkTest.t.sol
+++ b/tests/staking/MigratorForkTest.t.sol
@@ -22,7 +22,8 @@ contract MigratorForkTest is Test {
     IMintableERC20 public ogv;
     IMintableERC20 public ogn;
 
-    address public ogvWhale = Addresses.GOV_MULTISIG;
+    uint256 constant OGN_EPOCH = 1717041600; // May 30, 2024 GMT
+    address public ogvWhale = 0x70fCE97d671E81080CA3ab4cc7A59aAc2E117137;
 
     constructor() {
         deployManager = new DeployManager();
@@ -44,6 +45,12 @@ contract MigratorForkTest is Test {
         ogn.approve(address(migrator), type(uint256).max);
         ogv.approve(address(veogv), type(uint256).max);
         vm.stopPrank();
+
+        vm.warp(OGN_EPOCH + 100 days);
+
+        if (veogv.balanceOf(ogvWhale) == 0) {
+            revert("Change OGV Whale address");
+        }
     }
 
     function testBalanceMigration() external {

--- a/tests/staking/OGNRewardsSourceForkTest.t.sol
+++ b/tests/staking/OGNRewardsSourceForkTest.t.sol
@@ -59,6 +59,8 @@ contract OGNRewardsSourceForkTest is Test {
         vm.startPrank(bob);
         ogn.approve(address(xogn), 1e70);
         vm.stopPrank();
+
+        vm.warp(OGN_EPOCH + 100 days);
     }
 
     function testRewardRate() external view {

--- a/tests/staking/OgvStaking.t.sol
+++ b/tests/staking/OgvStaking.t.sol
@@ -231,4 +231,13 @@ contract OgvStakingTest is Test {
         vm.expectRevert(bytes4(keccak256("NoLockupsToUnstake()")));
         staking.unstake(lockupIds);
     }
+
+    function testCollectRewardsPermission() public {
+        vm.prank(migrator);
+        staking.collectRewardsFrom(alice);
+
+        vm.prank(team);
+        vm.expectRevert(bytes4(keccak256("NotMigrator()")));
+        staking.collectRewardsFrom(alice);
+    }
 }

--- a/tests/staking/XOGNStakingForkTest.t..sol
+++ b/tests/staking/XOGNStakingForkTest.t..sol
@@ -62,7 +62,7 @@ contract XOGNStakingForkTest is Test {
         ogn.approve(address(xogn), 1e70);
         vm.stopPrank();
 
-        vm.warp(OGN_EPOCH + 100 days);
+        vm.warp(OGN_EPOCH);
     }
 
     function testTokenName() external view {
@@ -97,8 +97,6 @@ contract XOGNStakingForkTest is Test {
 
     function testUnstake() external {
         vm.startPrank(alice);
-
-        console.log(FixedRateRewardsSource(ognRewardsSource).previewRewards());
 
         xogn.stake(
             1000 ether, // 1k OGN

--- a/tests/staking/XOGNStakingForkTest.t..sol
+++ b/tests/staking/XOGNStakingForkTest.t..sol
@@ -61,6 +61,8 @@ contract XOGNStakingForkTest is Test {
         vm.startPrank(bob);
         ogn.approve(address(xogn), 1e70);
         vm.stopPrank();
+
+        vm.warp(OGN_EPOCH + 100 days);
     }
 
     function testTokenName() external view {

--- a/tests/staking/ZapperForkTest.t.sol
+++ b/tests/staking/ZapperForkTest.t.sol
@@ -15,6 +15,8 @@ import {ExponentialStaking} from "contracts/ExponentialStaking.sol";
 import {IMintableERC20} from "contracts/interfaces/IMintableERC20.sol";
 
 contract ZapperForkTest is Test {
+    uint256 constant OGN_EPOCH = 1717041600; // May 30, 2024 GMT
+
     DeployManager public deployManager;
 
     Migrator public migrator;
@@ -24,7 +26,7 @@ contract ZapperForkTest is Test {
     IMintableERC20 public ogv;
     IMintableERC20 public ogn;
 
-    address public ogvWhale = Addresses.GOV_MULTISIG;
+    address public ogvWhale = 0x70fCE97d671E81080CA3ab4cc7A59aAc2E117137;
 
     constructor() {
         deployManager = new DeployManager();
@@ -48,6 +50,12 @@ contract ZapperForkTest is Test {
         ogn.approve(address(migrator), type(uint256).max);
         ogv.approve(address(veogv), type(uint256).max);
         vm.stopPrank();
+
+        vm.warp(OGN_EPOCH + 100 days);
+
+        if (veogv.balanceOf(ogvWhale) == 0) {
+            revert("Change OGV Whale address");
+        }
     }
 
     function testBalanceMigration() external {


### PR DESCRIPTION
- Adds support for migrating just the rewards (without any lockup/balance)
- Adds support for calling `migrate()` without `lockupIds`

This also removes the need for the `MigrationZapper` contract. The frontend can always call a single method for all purposes

--------
If you made a contract change, make sure to complete the checklist below before merging it in master.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
