### PR TITLE
Deploy Plume Timelock

### DIFF
--- a/build/deployments.json
+++ b/build/deployments.json
@@ -34,5 +34,13 @@
     "contracts": {
       "TIMELOCK": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB"
     }
+  },
+  "98866": {
+    "executions": {
+      "001_Timelock": 1744818136
+    },
+    "contracts": {
+      "TIMELOCK": "0x6C6f8F839A7648949873D3D2beEa936FC2932e5c"
+    }
   }
 }

--- a/contracts/utils/Addresses.sol
+++ b/contracts/utils/Addresses.sol
@@ -23,10 +23,15 @@ library Addresses {
 
 library AddressesBase {
     // 5/8 multisig
-    address public constant GOVERNOR = 0x92A19381444A001d62cE67BaFF066fA1111d7202;
+    address public constant ADMIN = 0x92A19381444A001d62cE67BaFF066fA1111d7202;
 }
 
 library AddressesSonic {
     // 5/8 multisig
     address public constant ADMIN = 0xAdDEA7933Db7d83855786EB43a238111C69B00b6;
+}
+
+library AddressesPlume {
+    // 5/8 multisig
+    address public constant ADMIN = 0x92A19381444A001d62cE67BaFF066fA1111d7202;
 }

--- a/script/deploy/DeployManager.sol
+++ b/script/deploy/DeployManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.10;
 
 import "forge-std/Script.sol";
@@ -13,7 +13,7 @@ import {UpgradeMigratorScript} from "./mainnet/013_UpgradeMigratorScript.sol";
 import {XOGNGovernanceScript} from "./mainnet/014_xOGNGovernanceScript.sol";
 
 import {DeployTimelockScript} from "./base/001_Timelock.sol";
-
+import {DeployPlumeTimelockScript} from "./plume/001_Timelock.sol";
 import {SonicDeployTimelockScript} from "./sonic/001_Timelock.sol";
 
 import {VmSafe} from "forge-std/Vm.sol";
@@ -83,6 +83,8 @@ contract DeployManager is Script {
             _runDeployFile(new DeployTimelockScript());
         } else if (block.chainid == 146) {
             _runDeployFile(new SonicDeployTimelockScript());
+        } else if (block.chainid == 98866) {
+            _runDeployFile(new DeployPlumeTimelockScript());
         }
     }
 

--- a/script/deploy/plume/001_Timelock.sol
+++ b/script/deploy/plume/001_Timelock.sol
@@ -1,17 +1,17 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 
 pragma solidity 0.8.10;
 
 import "../AbstractScript.sol";
 import {Vm} from "forge-std/Vm.sol";
 
-import {AddressesBase} from "contracts/utils/Addresses.sol";
+import {AddressesPlume} from "contracts/utils/Addresses.sol";
 
 import {Timelock} from "contracts/Timelock.sol";
 
-contract DeployTimelockScript is AbstractScript {
+contract DeployPlumeTimelockScript is AbstractScript {
     string public constant override DEPLOY_NAME = "001_Timelock";
-    uint256 public constant override CHAIN_ID = 8453;
+    uint256 public constant override CHAIN_ID = 98866;
     bool public constant override proposalExecuted = false;
 
     constructor() {}
@@ -20,11 +20,15 @@ contract DeployTimelockScript is AbstractScript {
         console.log("Deploy:");
         console.log("------------");
 
-        address[] memory proposers = new address[](1);
-        address[] memory executors = new address[](1);
+        address[] memory proposers = new address[](2);
+        address[] memory executors = new address[](2);
 
-        proposers[0] = AddressesBase.ADMIN;
-        executors[0] = AddressesBase.ADMIN;
+        proposers[0] = AddressesPlume.ADMIN;
+        executors[0] = AddressesPlume.ADMIN;
+
+        // Giving myself permissions temporarily
+        proposers[1] = 0x58890A9cB27586E83Cb51d2d26bbE18a1a647245;
+        executors[1] = 0x58890A9cB27586E83Cb51d2d26bbE18a1a647245;
 
         // 1. Deploy Timelock
         Timelock timelock = new Timelock(


### PR DESCRIPTION
### Deployments
- Timelock: [0x6C6f8F839A7648949873D3D2beEa936FC2932e5c](https://phoenix-explorer.plumenetwork.xyz/address/0x6C6f8F839A7648949873D3D2beEa936FC2932e5c)
- Delay set to 60s
- Executor, Canceller and Proposer role granted to Plume Admin (5/8 multisig) [0x92A19381444A001d62cE67BaFF066fA1111d7202](https://phoenix-explorer.plumenetwork.xyz/address/0x92A19381444A001d62cE67BaFF066fA1111d7202)
  - Executor and Proposer roles are set in the constructor. Canceller is [scheduled](https://phoenix-explorer.plumenetwork.xyz/tx/0xf17d509d04ca324f3986a1afd3a57c45f2cbbfa0018f16b27482512c7b95324d) and [executed](https://phoenix-explorer.plumenetwork.xyz/tx/0x3c73338fa2e59e35bedd42527a3a542a928af130df0a5c0228f1ff94c48b0cc8) separately
- Deployer also has Executor and Proposer role, this will be revoked before we go live
- 2/8 has Executor role, [scheduled](https://phoenix-explorer.plumenetwork.xyz/tx/0xbf28bc146ae87ca7ca881a019f15f425acf47b0f2aacf5c06bf0e7bb09367fe7) and [executed](https://phoenix-explorer.plumenetwork.xyz/tx/0x2c06c16b166b067d2fa2edb6d12d723a7c7c9e6b374a76e2709f1359ea1bcf01) on the Timelock after deployment